### PR TITLE
Update go deps build image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -27,7 +27,7 @@ build-cosign:
     SAVE ARTIFACT /ko-app/cosign cosign
 
 go-deps:
-    FROM golang:$GOLANG_VERSION
+    FROM gcr.io/spectro-images-public/golang:1.19-debian
     WORKDIR /build
     COPY go.mod go.sum ./
     RUN go mod download

--- a/Earthfile
+++ b/Earthfile
@@ -27,7 +27,7 @@ build-cosign:
     SAVE ARTIFACT /ko-app/cosign cosign
 
 go-deps:
-    FROM gcr.io/spectro-images-public/golang:1.19-debian
+    FROM gcr.io/spectro-images-public/golang:1.19-bullseye
     WORKDIR /build
     COPY go.mod go.sum ./
     RUN go mod download


### PR DESCRIPTION
switching to bullseye
/system/providers/agent-provider-kubeadm: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /system/providers/agent-provider-kubeadm) 