### PR TITLE
update go build to debian bullseye 1.19

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -27,7 +27,7 @@ build-cosign:
     SAVE ARTIFACT /ko-app/cosign cosign
 
 go-deps:
-    FROM gcr.io/spectro-images-public/golang:1.19-bullseye
+    FROM gcr.io/spectro-dev-public/golang:1.19-debian
     WORKDIR /build
     COPY go.mod go.sum ./
     RUN go mod download


### PR DESCRIPTION
switching to bullseye
/system/providers/agent-provider-kubeadm: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /system/providers/agent-provider-kubeadm)