### PR TITLE
regenrate kubelet kubeconfig to have server as node ip instead of vip

### DIFF
--- a/scripts/kube-reconfigure.sh
+++ b/scripts/kube-reconfigure.sh
@@ -78,6 +78,10 @@ regenerate_apiserver_certs_sans() {
 
 regenerate_kubelet_envs() {
   echo "$kubelet_envs" > /var/lib/kubelet/kubeadm-flags.env
+
+  mv /etc/kubernetes/kubelet.conf /etc/kubernetes/kubelet.conf.bak
+  kubeadm init phase kubeconfig kubelet
+
   systemctl restart kubelet
 }
 

--- a/stages/init.go
+++ b/stages/init.go
@@ -47,7 +47,7 @@ func GetInitYipStagesV1Beta3(clusterCtx *domain.ClusterContext, kubeadmConfig do
 		getKubeadmPostInitStage(clusterCtx.RootPath),
 		getKubeadmInitUpgradeStage(clusterCtx),
 		getKubeadmInitCreateClusterConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.InitConfiguration, clusterCtx.RootPath),
-		getKubeadmInitCreateKubeletConfigStage(kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath),
+		getKubeadmInitCreateKubeletConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath),
 		getKubeadmInitReconfigureStage(clusterCtx),
 	}
 }
@@ -68,7 +68,7 @@ func GetInitYipStagesV1Beta4(clusterCtx *domain.ClusterContext, kubeadmConfig do
 		getKubeadmPostInitStage(clusterCtx.RootPath),
 		getKubeadmInitUpgradeStage(clusterCtx),
 		getKubeadmInitCreateClusterConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.InitConfiguration, clusterCtx.RootPath),
-		getKubeadmInitCreateKubeletConfigStage(kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath),
+		getKubeadmInitCreateKubeletConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath),
 		getKubeadmInitReconfigureStage(clusterCtx),
 	}
 }
@@ -133,8 +133,8 @@ func getKubeadmInitCreateClusterConfigStage(clusterCfgObj, initCfgObj runtime.Ob
 	return utils.GetFileStage("Generate Cluster Config File", filepath.Join(rootPath, configurationPath, "cluster-config.yaml"), getUpdatedInitClusterConfig(clusterCfgObj, initCfgObj))
 }
 
-func getKubeadmInitCreateKubeletConfigStage(kubeletCfg kubeletv1beta1.KubeletConfiguration, rootPath string) yip.Stage {
-	return utils.GetFileStage("Generate Kubelet Config File", filepath.Join(rootPath, configurationPath, "kubelet-config.yaml"), getUpdatedKubeletConfig(kubeletCfg))
+func getKubeadmInitCreateKubeletConfigStage(clusterCfgObj, kubeletCfg runtime.Object, rootPath string) yip.Stage {
+	return utils.GetFileStage("Generate Kubelet Config File", filepath.Join(rootPath, configurationPath, "kubelet-config.yaml"), getUpdatedKubeletConfig(clusterCfgObj, kubeletCfg))
 }
 
 func getKubeadmInitReconfigureStage(clusterCtx *domain.ClusterContext) yip.Stage {
@@ -229,8 +229,8 @@ func getUpdatedInitClusterConfig(clusterCfgObj, initCfgObj runtime.Object) strin
 	return printObj([]runtime.Object{clusterCfgObj, initCfgObj})
 }
 
-func getUpdatedKubeletConfig(kubeletCfg kubeletv1beta1.KubeletConfiguration) string {
-	return printObj([]runtime.Object{&kubeletCfg})
+func getUpdatedKubeletConfig(clusterCfgObj, kubeletCfg runtime.Object) string {
+	return printObj([]runtime.Object{clusterCfgObj, kubeletCfg})
 }
 
 func printObj(objects []runtime.Object) string {

--- a/stages/join.go
+++ b/stages/join.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/kairos-io/kairos/provider-kubeadm/domain"
 
-	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-
 	"github.com/kairos-io/kairos-sdk/clusterplugin"
 	"github.com/kairos-io/kairos/provider-kubeadm/utils"
 	yip "github.com/mudler/yip/pkg/schema"
@@ -36,7 +34,7 @@ func GetJoinYipStagesV1Beta3(clusterCtx *domain.ClusterContext, kubeadmConfig do
 	if clusterCtx.NodeRole != clusterplugin.RoleWorker {
 		joinStg = append(joinStg,
 			getKubeadmJoinCreateClusterConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.InitConfiguration, &kubeadmConfig.JoinConfiguration, clusterCtx.RootPath),
-			getKubeadmJoinCreateKubeletConfigStage(kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath))
+			getKubeadmJoinCreateKubeletConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath))
 	}
 
 	return append(joinStg, getKubeadmJoinReconfigureStage(clusterCtx))
@@ -58,7 +56,7 @@ func GetJoinYipStagesV1Beta4(clusterCtx *domain.ClusterContext, kubeadmConfig do
 	if clusterCtx.NodeRole != clusterplugin.RoleWorker {
 		joinStg = append(joinStg,
 			getKubeadmJoinCreateClusterConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.InitConfiguration, &kubeadmConfig.JoinConfiguration, clusterCtx.RootPath),
-			getKubeadmJoinCreateKubeletConfigStage(kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath))
+			getKubeadmJoinCreateKubeletConfigStage(&kubeadmConfig.ClusterConfiguration, &kubeadmConfig.KubeletConfiguration, clusterCtx.RootPath))
 	}
 
 	return append(joinStg, getKubeadmJoinReconfigureStage(clusterCtx))
@@ -198,8 +196,8 @@ func getKubeadmJoinCreateClusterConfigStage(clusterCfgObj, initCfgObj, joinCfgOb
 	return utils.GetFileStage("Generate Cluster Config File", filepath.Join(rootPath, configurationPath, "cluster-config.yaml"), getUpdatedJoinClusterConfig(clusterCfgObj, initCfgObj, joinCfgObj))
 }
 
-func getKubeadmJoinCreateKubeletConfigStage(kubeletCfg kubeletv1beta1.KubeletConfiguration, rootPath string) yip.Stage {
-	return utils.GetFileStage("Generate Kubelet Config File", filepath.Join(rootPath, configurationPath, "kubelet-config.yaml"), getUpdatedKubeletConfig(kubeletCfg))
+func getKubeadmJoinCreateKubeletConfigStage(clusterCfgObj, kubeletCfg runtime.Object, rootPath string) yip.Stage {
+	return utils.GetFileStage("Generate Kubelet Config File", filepath.Join(rootPath, configurationPath, "kubelet-config.yaml"), getUpdatedKubeletConfig(clusterCfgObj, kubeletCfg))
 }
 
 func getKubeadmJoinReconfigureStage(clusterCtx *domain.ClusterContext) yip.Stage {


### PR DESCRIPTION
Also, fixed a bug where the kubelet upload command to the kubelet-config config map was not working. Now kubelet-config will also have clusterconfiguration as per the requirement of the kubelet upload command.