### PR TITLE
fixed kubelet binary path after upgrade

### DIFF
--- a/scripts/kube-join.sh
+++ b/scripts/kube-join.sh
@@ -20,6 +20,16 @@ export PATH="$PATH:$root_path/usr/local/bin"
 
 KUBE_VIP_LOC="/etc/kubernetes/manifests/kube-vip.yaml"
 
+restart_containerd() {
+  if systemctl cat spectro-containerd >/dev/null 2<&1; then
+    systemctl restart spectro-containerd
+  fi
+
+  if systemctl cat containerd >/dev/null 2<&1; then
+    systemctl restart containerd
+  fi
+}
+
 do_kubeadm_reset() {
   if [ -S /run/spectro/containerd/containerd.sock ]; then
     kubeadm reset -f --cri-socket unix:///run/spectro/containerd/containerd.sock --cleanup-tmp-dir
@@ -28,14 +38,12 @@ do_kubeadm_reset() {
   fi
   iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X && rm -rf /etc/kubernetes/etcd /etc/kubernetes/manifests /etc/kubernetes/pki
   rm -rf "$root_path"/etc/cni/net.d
+  if [ -f /run/systemd/system/etc-cni-net.d.mount ]; then
+    mkdir -p "$root_path"/etc/cni/net.d
+    systemctl restart etc-cni-net.d.mount
+  fi
   systemctl daemon-reload
-  if systemctl cat spectro-containerd >/dev/null 2<&1; then
-    systemctl restart spectro-containerd
-  fi
-
-  if systemctl cat containerd >/dev/null 2<&1; then
-    systemctl restart containerd
-  fi
+  restart_containerd
 }
 
 backup_kube_vip_manifest_if_present() {
@@ -46,8 +54,8 @@ backup_kube_vip_manifest_if_present() {
 
 restore_kube_vip_manifest_after_reset() {
   if [ -f "$root_path/opt/kubeadm/kube-vip.yaml" ] && [ "$NODE_ROLE" != "worker" ]; then
-      mkdir -p "$root_path"/etc/kubernetes/manifests
-      cp "$root_path"/opt/kubeadm/kube-vip.yaml $KUBE_VIP_LOC
+    mkdir -p "$root_path"/etc/kubernetes/manifests
+    cp "$root_path"/opt/kubeadm/kube-vip.yaml $KUBE_VIP_LOC
   fi
 }
 

--- a/scripts/kube-pre-init.sh
+++ b/scripts/kube-pre-init.sh
@@ -25,6 +25,7 @@ if [ -f "$root_path"/opt/spectrocloud/kubeadm/bin/kubelet ]; then
 fi
 
 if [ ! -f "$root_path"/usr/local/bin/kubelet ]; then
+  mkdir -p "$root_path"/usr/local/bin
   cp "$root_path"/opt/kubeadm/bin/kubelet "$root_path"/usr/local/bin/kubelet
   systemctl enable kubelet && systemctl start kubelet
 fi

--- a/scripts/kube-upgrade.sh
+++ b/scripts/kube-upgrade.sh
@@ -48,12 +48,22 @@ delete_lock_config_map() {
   fi
 }
 
+restart_containerd() {
+  if systemctl cat spectro-containerd >/dev/null 2<&1; then
+    systemctl restart spectro-containerd
+  fi
+
+  if systemctl cat containerd >/dev/null 2<&1; then
+    systemctl restart containerd
+  fi
+}
+
 upgrade_kubelet() {
   echo "upgrading kubelet"
   systemctl stop kubelet
-  cp "$root_path"/opt/kubeadm/bin/kubelet "$root_path"/usr/local/bin/kubelet
+  cp /opt/kubeadm/bin/kubelet "$root_path"/usr/local/bin/kubelet
   systemctl daemon-reload && systemctl restart kubelet
-  systemctl restart containerd
+  restart_containerd
   echo "kubelet upgraded"
 }
 


### PR DESCRIPTION
Fixed issues related to the kubelet binary parent directory not being present during init and after-upgrade.
Fixed an issue related to init where the net.d directory was in-accessible if a reset was triggered due to failed init.