### PR TITLE
fix(earthfile): download binaries from k8s cdn

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -101,9 +101,9 @@ DOWNLOAD_BINARIES:
         RUN curl -L --remote-name-all https://storage.googleapis.com/spectro-fips/${KUBEADM_VERSION}/kubectl
     ELSE
         RUN curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz" | sudo tar -C /usr/bin/ -xz
-        RUN curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/v${KUBEADM_VERSION}/bin/linux/amd64/kubeadm
-        RUN curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/v${KUBEADM_VERSION}/bin/linux/amd64/kubelet
-        RUN curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/v${KUBEADM_VERSION}/bin/linux/amd64/kubectl
+        RUN curl -L --remote-name-all https://dl.k8s.io/v${KUBEADM_VERSION}/bin/linux/amd64/kubeadm
+        RUN curl -L --remote-name-all https://dl.k8s.io/v${KUBEADM_VERSION}/bin/linux/amd64/kubelet
+        RUN curl -L --remote-name-all https://dl.k8s.io/v${KUBEADM_VERSION}/bin/linux/amd64/kubectl
     END
 
 SETUP_CONTAINERD:


### PR DESCRIPTION
Starting from July 2023, Kubernets has a new Content Delivery Network for binaries (more info: https://kubernetes.io/blog/2023/06/09/dl-adopt-cdn/)