### PR TITLE
Build and push provider binaries to github releases

### DIFF
--- a/.github/workflows/provider-packaging.yaml
+++ b/.github/workflows/provider-packaging.yaml
@@ -84,3 +84,22 @@ jobs:
           version: "latest"
       - run: echo "${{ secrets.ARTIFACT_IMG_PUSH_EDGE }}" | base64 -d | docker login -u _json_key --password-stdin us-docker.pkg.dev
       - run: earthly --ci --push --output +provider-package-merge --IMAGE_REPOSITORY=${{ matrix.image_repository }} --FIPS_ENABLED=${{ matrix.fips }}
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git fetch --prune --unshallow
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Install gcc for arm64
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 build/
 local/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,73 @@
+# Make sure to check the documentation at http://goreleaser.com
+version: 2
+project_name: agent-provider-kubeadm
+builds:
+  - ldflags:
+      - -w -s -X github.com/kairos-io/kairos/provider-kubeadm/version.Version={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    binary: '{{ .ProjectName }}'
+    id: default
+  - ldflags:
+      - -w -s -X github.com/kairos-io/kairos/provider-kubeadm/version.Version={{.Tag}}
+    env:
+      - CGO_ENABLED=1
+      - GOEXPERIMENT=boringcrypto
+    goos:
+      - linux
+    goarch:
+      - amd64
+    binary: '{{ .ProjectName }}'
+    id: fips-amd64
+    hooks:
+      post:
+        - bash -c 'set -e; go version {{.Path}} | grep boringcrypto || (echo "boringcrypto not found" && exit 1)'
+  - ldflags:
+      - -w -s -X github.com/kairos-io/kairos/provider-kubeadm/version.Version={{.Tag}}
+    env:
+      - CGO_ENABLED=1
+      - GOEXPERIMENT=boringcrypto
+      - CC=aarch64-linux-gnu-gcc
+    goos:
+      - linux
+    goarch:
+      - arm64
+    binary: '{{ .ProjectName }}'
+    id: fips-arm64
+    hooks:
+      post:
+        - bash -c 'set -e; go version {{.Path}} | grep boringcrypto || (echo "boringcrypto not found" && exit 1)'
+source:
+  enabled: true
+  name_template: '{{ .ProjectName }}-{{ .Tag }}-source'
+archives:
+  - id: default-archive
+    ids:
+      - default
+    name_template: '{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}-{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+  - id: fips-archive
+    ids:
+     - fips-arm64
+     - fips-amd64
+    name_template: '{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}-{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}-fips'
+checksum:
+  name_template: '{{ .ProjectName }}-{{ .Tag }}-checksums.txt'
+snapshot:
+  version_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^Merge pull request'
+env:
+  - GOSUMDB=sum.golang.org
+before:
+  hooks:
+    - go mod tidy


### PR DESCRIPTION
This follows the same patter as other binaries under the Kairos umbrella in which we push the built binaries for arches and fips into github releases so they can be consumed directly from there.