### PR TITLE
Add a Dockerfile to build with kairos-init and instructions in README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,15 @@ RUN BASE_IMAGE_NAME=$(echo ${BASE_IMAGE} | grep -o '[^/]*:' | rev | cut -c2- | r
 
 
 
+# Install iSCSI packages to satisfy dracut iSCSI module requirements
+# This prevents the "iscsiroot requested but kernel/initrd does not support iscsi" error
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        open-iscsi \
+        iscsiuio && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Now run kairos-init at the very end after all setup is complete
 # This ensures all binaries and configurations are available for initramfs creation
 # Use the resolved K8s version or generate a proper semver if VERSION is "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 # Build arguments
 ARG BASE_IMAGE=quay.io/kairos/fedora:40-core-amd64-generic-v3.5.1
+# IMPORTANT: This version must match the kubernetesVersion in your configuration files
+# (e.g., kairos-master-minimal.yaml, kairos-worker-minimal.yaml)
 ARG KUBEADM_VERSION=latest
 ARG CRICTL_VERSION=1.25.0
 ARG RELEASE_VERSION=0.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile to build Kairos image with kubeadm provider using kairos-init
 
 # Build arguments
-ARG BASE_IMAGE=quay.io/kairos/ubuntu:24.04-core-amd64-generic-v3.2.4
+ARG BASE_IMAGE=quay.io/kairos/fedora:40-core-amd64-generic-v3.5.1
 ARG KUBEADM_VERSION=latest
 ARG CRICTL_VERSION=1.25.0
 ARG RELEASE_VERSION=0.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,194 @@
+# Multi-stage Dockerfile to build Kairos image with kubeadm provider using kairos-init
+
+# Build arguments
+ARG BASE_IMAGE=quay.io/kairos/ubuntu:24.04-core-amd64-generic-v3.2.4
+ARG KUBEADM_VERSION=latest
+ARG CRICTL_VERSION=1.25.0
+ARG RELEASE_VERSION=0.4.0
+ARG FIPS_ENABLED=false
+ARG KAIROS_INIT_VERSION=v0.6.0
+ARG VERSION=latest
+
+# Stage 1: Get kairos-init binary
+FROM quay.io/kairos/kairos-init:${KAIROS_INIT_VERSION} AS kairos-init
+
+# Stage 2: Build the provider binary
+FROM golang:1.24-alpine AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG VERSION
+ENV GO_LDFLAGS="-X github.com/kairos-io/kairos/provider-kubeadm/version.Version=${VERSION} -w -s"
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "${GO_LDFLAGS}" -o agent-provider-kubeadm main.go
+
+# Stage 3: Download Kubernetes binaries
+FROM alpine:latest AS k8s-binaries
+ARG KUBEADM_VERSION
+ARG CRICTL_VERSION
+ARG FIPS_ENABLED=false
+
+RUN apk add --no-cache curl jq
+
+WORKDIR /binaries
+
+# Resolve "latest" to actual version if needed
+RUN if [ "$KUBEADM_VERSION" = "latest" ]; then \
+        if [ "$FIPS_ENABLED" = "true" ]; then \
+            # For FIPS, use the latest available version in spectro-fips (1.25.2 as of last check)
+            RESOLVED_VERSION="1.25.2"; \
+        else \
+            # Get the latest stable version from Kubernetes API
+            RESOLVED_VERSION=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | jq -r '.tag_name'); \
+        fi; \
+        echo "Resolved KUBEADM_VERSION from 'latest' to: $RESOLVED_VERSION"; \
+        echo "$RESOLVED_VERSION" > /tmp/k8s_version; \
+    else \
+        echo "$KUBEADM_VERSION" > /tmp/k8s_version; \
+    fi
+
+# Download crictl
+RUN if [ "$FIPS_ENABLED" = "true" ]; then \
+        curl -L "https://storage.googleapis.com/spectro-fips/cri-tools/v${CRICTL_VERSION}/cri-tools-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -xz; \
+    else \
+        curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -xz; \
+    fi
+
+# Download kubeadm, kubelet, kubectl
+RUN K8S_VERSION=$(cat /tmp/k8s_version) && \
+    if [ "$FIPS_ENABLED" = "true" ]; then \
+        curl -L -o kubeadm "https://storage.googleapis.com/spectro-fips/${K8S_VERSION}/kubeadm" && \
+        curl -L -o kubelet "https://storage.googleapis.com/spectro-fips/${K8S_VERSION}/kubelet" && \
+        curl -L -o kubectl "https://storage.googleapis.com/spectro-fips/${K8S_VERSION}/kubectl"; \
+    else \
+        curl -L -o kubeadm "https://dl.k8s.io/${K8S_VERSION}/bin/linux/amd64/kubeadm" && \
+        curl -L -o kubelet "https://dl.k8s.io/${K8S_VERSION}/bin/linux/amd64/kubelet" && \
+        curl -L -o kubectl "https://dl.k8s.io/${K8S_VERSION}/bin/linux/amd64/kubectl"; \
+    fi
+
+RUN chmod +x kubeadm kubelet kubectl crictl
+
+# Save the resolved version for later use
+RUN cp /tmp/k8s_version /binaries/k8s_version
+
+# Stage 4: Download containerd and CNI plugins
+FROM alpine:latest AS containerd-binaries
+ARG FIPS_ENABLED=false
+
+RUN apk add --no-cache curl
+
+WORKDIR /containerd
+
+# Download containerd
+RUN if [ "$FIPS_ENABLED" = "true" ]; then \
+        curl -sSL "https://storage.googleapis.com/spectro-fips/containerd/v1.6.4/containerd-1.6.4-linux-amd64.tar.gz" | tar -xz; \
+    else \
+        curl -sSL "https://github.com/containerd/containerd/releases/download/v1.6.4/containerd-1.6.4-linux-amd64.tar.gz" | tar -xz; \
+    fi
+
+# Download runc
+RUN if [ "$FIPS_ENABLED" = "true" ]; then \
+        curl -SL -o runc "https://storage.googleapis.com/spectro-fips/runc-1.1.4/runc"; \
+    else \
+        curl -SL -o runc "https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64"; \
+    fi
+
+RUN chmod +x runc
+
+# Download CNI plugins
+RUN mkdir -p cni-plugins && \
+    if [ "$FIPS_ENABLED" = "true" ]; then \
+        curl -sSL "https://storage.googleapis.com/spectro-fips/cni-plugins/v1.1.1/cni-plugins-1.1.1-linux-amd64.tar.gz" | tar -C cni-plugins -xz; \
+    else \
+        curl -sSL "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz" | tar -C cni-plugins -xz; \
+    fi
+
+# Stage 5: Main image
+FROM ${BASE_IMAGE}
+ARG KUBEADM_VERSION
+ARG RELEASE_VERSION
+ARG VERSION
+ARG FIPS_ENABLED=false
+
+# Copy kairos-init (but don't run it yet)
+COPY --from=kairos-init /kairos-init /kairos-init
+
+# Copy Kubernetes binaries and version info
+COPY --from=k8s-binaries /binaries/kubeadm /usr/bin/kubeadm
+COPY --from=k8s-binaries /binaries/kubelet /usr/bin/kubelet
+COPY --from=k8s-binaries /binaries/kubectl /usr/bin/kubectl
+COPY --from=k8s-binaries /binaries/crictl /usr/bin/crictl
+COPY --from=k8s-binaries /binaries/k8s_version /tmp/k8s_version
+
+# Setup containerd
+COPY --from=containerd-binaries /containerd/bin/* /opt/bin/
+COPY --from=containerd-binaries /containerd/runc /opt/bin/runc
+RUN mkdir -p /opt/cni/bin
+COPY --from=containerd-binaries /containerd/cni-plugins/* /opt/cni/bin/
+
+# Copy containerd from /opt/bin/ctr to /usr/bin/ctr for compatibility
+RUN cp /opt/bin/ctr /usr/bin/ctr
+
+# Download and setup containerd systemd service
+RUN curl -sSL "https://raw.githubusercontent.com/containerd/containerd/main/containerd.service" | \
+    sed "s?ExecStart=/usr/local/bin/containerd?ExecStart=/opt/bin/containerd?" > /etc/systemd/system/containerd.service
+
+# Setup kubelet systemd service
+RUN curl -sSL "https://raw.githubusercontent.com/kubernetes/release/v${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" > /etc/systemd/system/kubelet.service && \
+    mkdir -p /etc/systemd/system/kubelet.service.d && \
+    curl -sSL "https://raw.githubusercontent.com/kubernetes/release/v${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+
+# Copy containerd configuration
+COPY containerd/config.toml /etc/containerd/config.toml
+
+# Copy scripts
+RUN mkdir -p /opt/kubeadm/scripts
+COPY scripts/* /opt/kubeadm/scripts/
+
+# Copy provider binary
+COPY --from=builder /build/agent-provider-kubeadm /system/providers/agent-provider-kubeadm
+
+# Load Kubernetes images (only if not FIPS)
+RUN if [ "$FIPS_ENABLED" != "true" ]; then \
+        K8S_VERSION=$(cat /tmp/k8s_version) && \
+        bash /opt/kubeadm/scripts/kube-images-load.sh ${K8S_VERSION}; \
+    fi
+
+# Setup kernel modules
+RUN echo "overlay" >> /etc/modules-load.d/k8s.conf && \
+    echo "br_netfilter" >> /etc/modules-load.d/k8s.conf
+
+# Setup networking parameters
+RUN echo "net.bridge.bridge-nf-call-iptables=1" >> /etc/sysctl.d/k8s.conf && \
+    echo "net.bridge.bridge-nf-call-ip6tables=1" >> /etc/sysctl.d/k8s.conf && \
+    echo "net.ipv4.ip_forward=1" >> /etc/sysctl.d/k8s.conf
+
+# Set OS identification environment variables
+ARG BASE_IMAGE
+ARG IMAGE_REPOSITORY=quay.io/kairos
+RUN BASE_IMAGE_NAME=$(echo ${BASE_IMAGE} | grep -o '[^/]*:' | rev | cut -c2- | rev) && \
+    BASE_IMAGE_TAG=$(echo ${BASE_IMAGE} | grep -o ':.*' | cut -c2-) && \
+    KUBEADM_VERSION_TAG=$(echo ${KUBEADM_VERSION} | sed 's/+/-/') && \
+    echo "OS_ID=${BASE_IMAGE_NAME}-kubeadm" >> /etc/os-release && \
+    echo "OS_NAME=${BASE_IMAGE_NAME}-kubeadm:${BASE_IMAGE_TAG}" >> /etc/os-release && \
+    echo "OS_REPO=${IMAGE_REPOSITORY}" >> /etc/os-release && \
+    echo "OS_VERSION=${KUBEADM_VERSION_TAG}_${VERSION}" >> /etc/os-release && \
+    echo "OS_LABEL=${BASE_IMAGE_TAG}_${KUBEADM_VERSION_TAG}_${VERSION}" >> /etc/os-release
+
+
+
+# Now run kairos-init at the very end after all setup is complete
+# This ensures all binaries and configurations are available for initramfs creation
+# Use the resolved K8s version or generate a proper semver if VERSION is "latest"
+RUN KAIROS_VERSION="${VERSION}" && \
+    if [ "${VERSION}" = "latest" ]; then \
+        K8S_VERSION=$(cat /tmp/k8s_version) && \
+        KAIROS_VERSION="v1.0.0-${K8S_VERSION}"; \
+    fi && \
+    echo "Running kairos-init with version: ${KAIROS_VERSION}" && \
+    /kairos-init -l info -m generic --version "${KAIROS_VERSION}"
+
+RUN /kairos-init validate;
+
+# Clean up kairos-init binary
+RUN rm /kairos-init

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,14 +177,11 @@ RUN BASE_IMAGE_NAME=$(echo ${BASE_IMAGE} | grep -o '[^/]*:' | rev | cut -c2- | r
 
 
 
-# Install iSCSI packages to satisfy dracut iSCSI module requirements
+# Configure dracut to omit iSCSI modules that cause boot failures
 # This prevents the "iscsiroot requested but kernel/initrd does not support iscsi" error
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        open-iscsi \
-        iscsiuio && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Following the pattern from official Kairos examples for Ubuntu builds
+RUN mkdir -p /etc/dracut.conf.d && \
+    echo 'omit_dracutmodules+=" iscsi iscsiroot "' > /etc/dracut.conf.d/no-iscsi.conf
 
 # Now run kairos-init at the very end after all setup is complete
 # This ensures all binaries and configurations are available for initramfs creation

--- a/README.md
+++ b/README.md
@@ -100,35 +100,30 @@ stages:
 
 3. Wait for the node to boot and initialize the cluster
 
-### 2. Get Join Token
+### 2. Deploy Worker Nodes
 
-Once the master node is running, SSH to it and get the join token:
+1. Update the worker configuration:
+   - Set the same `cluster_token` string as used in your master configuration
+   - Set the same `control_plane_host` as the master
+   - Deploy as many worker nodes as needed
+
+> **Note**: The `cluster_token` can be any string of your choice. The provider automatically converts it to a valid kubeadm token format. You just need to use the same string on both master and worker nodes.
+
+2. Deploy worker nodes using your preferred method
+
+3. Workers will automatically join the cluster
+
+### 3. Verify Cluster
+
+Once all nodes are deployed, you can verify the cluster by SSH'ing to the master node:
 
 ```bash
 # SSH to master node
 ssh kairos@<master-ip>
 
-# Generate join token and command
-sudo kubeadm token create --print-join-command
+# Check cluster status
+kubectl get nodes
 ```
-
-This will output something like:
-```bash
-kubeadm join 10.10.131.183:6443 --token abc123.defghijk456789 --discovery-token-ca-cert-hash sha256:1234567890abcdef...
-```
-
-Extract the token part (e.g., `abc123.defghijk456789`) for your worker configuration.
-
-### 3. Deploy Worker Nodes
-
-1. Update the worker configuration:
-   - Set the `cluster_token` from step 2
-   - Set the same `control_plane_host` as the master
-   - Deploy as many worker nodes as needed
-
-2. Deploy worker nodes using your preferred method
-
-3. Workers will automatically join the cluster
 
 ### 4. Install CNI Network Plugin
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ export IMAGE_NAME=mykairos-kubeadm
 # Build the image
 docker build \
   --build-arg KUBERNETES_VERSION=${KUBERNETES_VERSION} \
-  --build-arg PROVIDER_KUBEADM_VERSION=v4.7.0-rc.4 \
   --build-arg TARGETARCH=amd64 \
   -t ${IMAGE_NAME}:latest \
   .

--- a/README.md
+++ b/README.md
@@ -481,12 +481,14 @@ For ARM64 builds:
 ```bash
 docker build \
   --build-arg KUBEADM_VERSION=v1.32.0 \
-  --build-arg PROVIDER_KUBEADM_VERSION=v4.7.0-rc.4 \
+  --build-arg VERSION=v4.7.0-rc.4 \
   --build-arg TARGETARCH=arm64 \
   --platform linux/arm64 \
   -t ${IMAGE_NAME}-arm64:latest \
   .
 ```
+
+> **Note:** The `VERSION` build argument sets the version string that gets embedded into the provider binary for reporting purposes. It does not affect which version of the provider code is built - that is determined by the Git commit/tag you're building from.
 
 #### Different Kubernetes Versions
 
@@ -494,7 +496,7 @@ docker build \
 # For Kubernetes v1.31.x
 docker build \
   --build-arg KUBEADM_VERSION=v1.31.3 \
-  --build-arg PROVIDER_KUBEADM_VERSION=v4.7.0-rc.4 \
+  --build-arg VERSION=v4.7.0-rc.4 \
   -t mykairos-kubeadm-v1.31:latest \
   .
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,407 @@
 Kairos provider for Kubeadm
 
 ## Overview
-This plugin provides comprehensive kubeadm cluster provisioning capabilities for Kairos, supporting both agent and appliance deployment modes.
+
+The provider-kubeadm enables Kairos to bootstrap Kubernetes clusters using kubeadm instead of the default k3s/k0s providers. This gives you a standard upstream Kubernetes cluster with full control over the configuration.
+
+## Prerequisites
+
+- Kairos image with provider-kubeadm and containerd (see [Building Custom Image](#building-custom-image) section)
+- Network connectivity between nodes
+- Basic understanding of Kubernetes networking
 
 ## Testing
 The project includes comprehensive unit and integration tests with full coverage verification. All tests are designed to run without external dependencies for reliable CI/CD execution.
+
+## Configuration Files
+
+### Master/Control Plane Node
+
+Use [`kairos-master-minimal.yaml`](./kairos-master-minimal.yaml) for the first node (control plane):
+
+```yaml
+#cloud-config
+# Minimal Kairos configuration for master/init node
+# After deployment, get the worker join token with:
+#   kubeadm token create --print-join-command
+install:
+  device: "auto"
+  auto: true
+  reboot: true
+
+cluster:
+  cluster_token: "your-cluster-token-here"
+  control_plane_host: 10.10.131.183  # VIP IP for the cluster
+  role: init
+  config: |
+    clusterConfiguration:
+      kubernetesVersion: v1.32.4
+      networking:
+        podSubnet: 192.168.0.0/16
+        serviceSubnet: 192.169.0.0/16
+
+stages:
+  initramfs:
+  - users:
+      kairos:
+        groups:
+          - sudo
+        passwd: kairos
+  - commands:
+    - ln -s /etc/kubernetes/admin.conf /run/kubeconfig
+```
+
+### Worker Nodes
+
+Use [`kairos-worker-minimal.yaml`](./kairos-worker-minimal.yaml) for worker nodes:
+
+```yaml
+#cloud-config
+# Minimal Kairos configuration for worker node
+install:
+  device: "auto"
+  auto: true
+  reboot: true
+
+cluster:
+  cluster_token: "your-cluster-token-here"  # Get from: kubeadm token create
+  control_plane_host: 10.10.131.183  # VIP IP for the cluster
+  role: worker
+
+stages:
+  initramfs:
+  - users:
+      kairos:
+        groups:
+          - sudo
+        passwd: kairos
+```
+
+## Deployment Steps
+
+### 1. Deploy Master Node
+
+1. Customize the master configuration:
+   - Set your desired `control_plane_host` IP address
+   - Update `kubernetesVersion` if needed
+   - Adjust network subnets if required
+   - Generate a secure cluster token (or use the auto-generated one)
+
+2. Deploy the master node using your preferred method (ISO, PXE, etc.)
+
+3. Wait for the node to boot and initialize the cluster
+
+### 2. Get Join Token
+
+Once the master node is running, SSH to it and get the join token:
+
+```bash
+# SSH to master node
+ssh kairos@<master-ip>
+
+# Generate join token and command
+sudo kubeadm token create --print-join-command
+```
+
+This will output something like:
+```bash
+kubeadm join 10.10.131.183:6443 --token abc123.defghijk456789 --discovery-token-ca-cert-hash sha256:1234567890abcdef...
+```
+
+Extract the token part (e.g., `abc123.defghijk456789`) for your worker configuration.
+
+### 3. Deploy Worker Nodes
+
+1. Update the worker configuration:
+   - Set the `cluster_token` from step 2
+   - Set the same `control_plane_host` as the master
+   - Deploy as many worker nodes as needed
+
+2. Deploy worker nodes using your preferred method
+
+3. Workers will automatically join the cluster
+
+### 4. Verify Cluster
+
+SSH to the master node and check cluster status:
+
+```bash
+# Check nodes
+kubectl get nodes
+
+# Check system pods
+kubectl get pods -n kube-system
+
+# Get cluster info
+kubectl cluster-info
+```
+
+## Configuration Details
+
+### Essential Settings
+
+- **`cluster_token`**: Bootstrap token for node authentication (expires after 24 hours)
+- **`control_plane_host`**: IP address where the Kubernetes API server will be accessible
+- **`role`**: Either `init` (first master), `controlplane` (additional masters), or `worker`
+- **`kubernetesVersion`**: Must match the kubeadm/kubelet binaries in your Kairos image
+
+### Network Configuration
+
+- **`podSubnet`**: IP range for pod networking (default: 192.168.0.0/16)
+- **`serviceSubnet`**: IP range for services (default: 192.169.0.0/16)
+
+Adjust these subnets if they conflict with your existing network infrastructure.
+
+### Auto-Detection
+
+This minimal configuration relies on kubeadm's auto-detection for:
+- Container runtime socket location
+- Node IP addresses
+- Default security settings
+
+If auto-detection fails, you can uncomment and customize the advanced settings in the configuration files.
+
+## Token Management
+
+### Important Notes
+
+- **Tokens are only needed during initial join** - once a node joins, it stays in the cluster permanently
+- **Tokens expire after 24 hours** by default for security
+- **Expired tokens don't affect existing nodes** - only prevent new nodes from joining
+
+### Token Commands
+
+```bash
+# List existing tokens
+kubeadm token list
+
+# Create new token (24h expiry)
+kubeadm token create
+
+# Create permanent token (use carefully!)
+kubeadm token create --ttl 0
+
+# Get full join command
+kubeadm token create --print-join-command
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Node not joining**: Check network connectivity and firewall rules
+2. **Token expired**: Generate a new token on the master node
+3. **IP conflicts**: Adjust podSubnet/serviceSubnet in master config
+4. **Auto-detection fails**: Uncomment and set explicit paths in config
+
+### Required Ports
+
+Ensure these ports are open between nodes:
+- 6443: Kubernetes API server
+- 2379-2380: etcd server client API
+- 10250: Kubelet API
+- 10251: kube-scheduler
+- 10252: kube-controller-manager
+
+## Building Custom Image
+
+The default Kairos images come with provider-kairos (k3s/k0s). To use provider-kubeadm, you need to build a custom image that includes:
+- containerd runtime
+- kubeadm, kubelet, and kubectl binaries (specific version)
+- provider-kubeadm plugin
+
+**Important**: The `kubernetesVersion` in your configuration must match the kubeadm/kubelet version in your image.
+
+### Prerequisites
+
+- Docker
+- Internet connection for downloading binaries
+
+### Step 1: Create Dockerfile
+
+Create a `Dockerfile` that extends the base Kairos image with provider-kubeadm:
+
+```dockerfile
+# Build stage for downloading provider-kubeadm
+FROM alpine:latest AS provider-kubeadm-downloader
+
+ARG PROVIDER_KUBEADM_VERSION=v4.7.0-rc.4
+ARG TARGETARCH=amd64
+
+# Install curl and checksum tools
+RUN apk add --no-cache curl sha256sum
+
+# Download provider-kubeadm binary and checksum
+WORKDIR /tmp
+RUN curl -fsSL -L "https://github.com/kairos-io/provider-kubeadm/releases/download/${PROVIDER_KUBEADM_VERSION}/agent-provider-kubeadm-${PROVIDER_KUBEADM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    -o provider-kubeadm.tar.gz
+RUN curl -fsSL -L "https://github.com/kairos-io/provider-kubeadm/releases/download/${PROVIDER_KUBEADM_VERSION}/agent-provider-kubeadm-${PROVIDER_KUBEADM_VERSION}-checksums.txt" \
+    -o checksums.txt
+
+# Verify checksum - extract expected hash and compare with actual
+RUN EXPECTED_HASH=$(grep "agent-provider-kubeadm-${PROVIDER_KUBEADM_VERSION}-linux-${TARGETARCH}.tar.gz" checksums.txt | cut -d' ' -f1) && \
+    ACTUAL_HASH=$(sha256sum provider-kubeadm.tar.gz | cut -d' ' -f1) && \
+    echo "Expected: $EXPECTED_HASH" && \
+    echo "Actual:   $ACTUAL_HASH" && \
+    [ "$EXPECTED_HASH" = "$ACTUAL_HASH" ] || (echo "Checksum mismatch!" && exit 1)
+
+# Extract binary
+RUN tar -xzf provider-kubeadm.tar.gz
+RUN chmod +x agent-provider-kubeadm
+
+# Declare global ARGs
+ARG KUBERNETES_VERSION=v1.32.0
+ARG KUBERNETES_DISTRO=kubeadm
+ARG MODEL=generic
+ARG TRUSTED_BOOT=false
+ARG VERSION=v3.1.1
+ARG KAIROS_INIT=v0.5.18
+
+# Get kairos-init stage
+FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
+
+# Main build stage
+FROM quay.io/kairos/ubuntu:24.04-core-amd64-generic-v3.1.1
+
+# Re-declare ARGs for this stage
+ARG KUBERNETES_VERSION=v1.32.0
+ARG KUBERNETES_DISTRO=kubeadm
+ARG MODEL=generic
+ARG TRUSTED_BOOT=false
+ARG VERSION=v3.1.1
+
+# Copy provider-kubeadm binary to the right location
+COPY --from=provider-kubeadm-downloader /tmp/agent-provider-kubeadm /system/providers/provider-kubeadm
+
+# Initialize Kairos with kubeadm (with retry for repository issues)
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    for i in 1 2 3; do \
+        echo "Attempt $i: Running kairos-init..."; \
+        /kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}" && \
+        /kairos-init validate -t "${TRUSTED_BOOT}" && break; \
+        echo "Attempt $i failed, retrying..."; \
+        sleep 5; \
+    done
+```
+
+### Step 2: Build the Docker Image
+
+Build your custom Kairos image:
+
+```bash
+# Set your desired Kubernetes version
+export KUBERNETES_VERSION=v1.32.0
+export IMAGE_NAME=mykairos-kubeadm
+
+# Build the image
+docker build \
+  --build-arg KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+  --build-arg PROVIDER_KUBEADM_VERSION=v4.7.0-rc.4 \
+  --build-arg TARGETARCH=amd64 \
+  -t ${IMAGE_NAME}:latest \
+  .
+```
+
+### Step 3: Create Bootable ISO
+
+Use Auroraboot to convert your Docker image into a bootable ISO:
+
+```bash
+# Create build directory
+mkdir -p build
+
+# Build ISO from your custom image
+docker run --rm -it \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v $PWD/build:/build \
+  quay.io/kairos/auroraboot:latest \
+    --debug build-iso \
+    --output /build \
+    docker://${IMAGE_NAME}:latest
+```
+
+### Step 4: Verify the Build
+
+Check that your ISO contains the provider-kubeadm:
+
+```bash
+# List the generated files
+ls -la build/
+
+# The ISO file should be present
+# Example: kairos-ubuntu-24.04-generic-amd64-generic-v3.1.1.iso
+```
+
+### Customization Options
+
+#### Different Architectures
+
+For ARM64 builds:
+
+```bash
+docker build \
+  --build-arg KUBERNETES_VERSION=v1.32.0 \
+  --build-arg PROVIDER_KUBEADM_VERSION=v4.7.0-rc.4 \
+  --build-arg TARGETARCH=arm64 \
+  --platform linux/arm64 \
+  -t ${IMAGE_NAME}-arm64:latest \
+  .
+```
+
+#### Different Kubernetes Versions
+
+```bash
+# For Kubernetes v1.31.x
+docker build \
+  --build-arg KUBERNETES_VERSION=v1.31.3 \
+  --build-arg PROVIDER_KUBEADM_VERSION=v4.7.0-rc.4 \
+  -t mykairos-kubeadm-v1.31:latest \
+  .
+```
+
+#### Different Base Images
+
+```bash
+# Using Fedora base instead of Ubuntu
+FROM quay.io/kairos/fedora:39-core-amd64-generic-v3.1.1 AS base-kairos
+```
+
+### Troubleshooting
+
+#### Build Issues
+
+1. **Provider download fails**: Check the [latest releases](https://github.com/kairos-io/provider-kubeadm/releases) for correct version
+2. **Checksum verification fails**: Version mismatch between binary and checksum file
+3. **Architecture mismatch**: Ensure `TARGETARCH` matches your target platform
+
+#### Runtime Issues
+
+1. **Provider not found**: Verify the binary is in `/system/providers/provider-kubeadm`
+2. **Version mismatch**: Ensure `KUBERNETES_VERSION` matches your configuration
+3. **Permission issues**: Binary should be executable (`chmod +x`)
+
+### Advanced Configuration
+
+For production builds, consider:
+
+- **Multi-stage optimization**: Reduce final image size
+- **Security scanning**: Scan for vulnerabilities
+- **Automated builds**: CI/CD pipeline for regular updates
+- **Version pinning**: Lock all component versions for reproducibility
+
+## Advanced Configuration
+
+For production deployments, consider:
+- High availability control plane setup
+- External etcd cluster
+- Load balancer for API server
+- Network policies and security hardening
+- Monitoring and logging setup
+
+## Contributing
+
+Feel free to submit issues and pull requests to improve this configuration and documentation.
+
+## License
+
+This configuration is provided under the same license as the Kairos project.

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -3,6 +3,8 @@
 # IMPORTANT: Update control_plane_host to your actual node IP address
 # After deployment, get the worker join token with:
 #   kubeadm token create --print-join-command
+hostname: master-{{ trunc 4 .MachineID }}
+
 install:
   device: "auto"
   auto: true

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -1,0 +1,35 @@
+#cloud-config
+# Minimal Kairos configuration for master/init node
+# After deployment, get the worker join token with:
+#   kubeadm token create --print-join-command
+install:
+  device: "auto"
+  auto: true
+  reboot: true
+
+cluster:
+  cluster_token: "your-cluster-token-here"
+  control_plane_host: 10.10.131.183  # VIP IP for the cluster
+  role: init
+  config: |
+    clusterConfiguration:
+      kubernetesVersion: v1.32.4
+      networking:
+        podSubnet: 192.168.0.0/16
+        serviceSubnet: 192.169.0.0/16
+    # initConfiguration:
+    #   nodeRegistration:
+    #     criSocket: unix:///run/containerd/containerd.sock
+    # joinConfiguration:
+    #   nodeRegistration:
+    #     criSocket: unix:///run/containerd/containerd.sock
+
+stages:
+  initramfs:
+  - users:
+      kairos:
+        groups:
+          - sudo
+        passwd: kairos
+  - commands:
+    - ln -s /etc/kubernetes/admin.conf /run/kubeconfig

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -22,7 +22,9 @@ cluster:
     clusterConfiguration:
       kubernetesVersion: v1.34.0
       controlPlaneEndpoint: "192.168.122.71:6443"  # ← SAME IP AS ABOVE
-      # networking: # Uses kubeadm defaults: podSubnet=10.244.0.0/16, serviceSubnet=10.96.0.0/12
+      networking:
+        podSubnet: 10.244.0.0/16      # Flannel default
+        serviceSubnet: 10.96.0.0/12   # Kubernetes default
     # initConfiguration:
     #   nodeRegistration:
     #     criSocket: unix:///run/containerd/containerd.sock
@@ -39,3 +41,5 @@ stages:
         passwd: kairos
   - commands:
     - ln -s /etc/kubernetes/admin.conf /run/kubeconfig
+    # Disable firewalld to prevent Kubernetes networking issues
+    - systemctl disable --now firewalld

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -1,8 +1,7 @@
 #cloud-config
 # Minimal Kairos configuration for master/init node
 # IMPORTANT: Update control_plane_host to your actual node IP address
-# After deployment, get the worker join token with:
-#   kubeadm token create --print-join-command
+# After deployment, workers should use the same cluster_token string
 hostname: master-{{ trunc 4 .MachineID }}
 
 install:
@@ -17,7 +16,7 @@ users:
       - admin
 
 cluster:
-  cluster_token: "your-cluster-token-here"
+  cluster_token: "your-cluster-token-here"  # Any string - workers must use the same string
   control_plane_host: 192.168.122.71  # ← CHANGE TO YOUR ACTUAL NODE IP
   role: init
   config: |

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -1,5 +1,6 @@
 #cloud-config
 # Minimal Kairos configuration for master/init node
+# IMPORTANT: Update control_plane_host to your actual node IP address
 # After deployment, get the worker join token with:
 #   kubeadm token create --print-join-command
 install:
@@ -7,16 +8,21 @@ install:
   auto: true
   reboot: true
 
+users:
+  - name: kairos
+    passwd: kairos
+    groups:
+      - admin
+
 cluster:
   cluster_token: "your-cluster-token-here"
-  control_plane_host: 10.10.131.183  # VIP IP for the cluster
+  control_plane_host: 192.168.122.71  # ← CHANGE TO YOUR ACTUAL NODE IP
   role: init
   config: |
     clusterConfiguration:
-      kubernetesVersion: v1.32.4
-      networking:
-        podSubnet: 192.168.0.0/16
-        serviceSubnet: 192.169.0.0/16
+      kubernetesVersion: v1.34.0
+      controlPlaneEndpoint: "192.168.122.71:6443"  # ← SAME IP AS ABOVE
+      # networking: # Uses kubeadm defaults: podSubnet=10.244.0.0/16, serviceSubnet=10.96.0.0/12
     # initConfiguration:
     #   nodeRegistration:
     #     criSocket: unix:///run/containerd/containerd.sock

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -27,12 +27,6 @@ cluster:
       networking:
         podSubnet: 10.244.0.0/16      # Flannel default
         serviceSubnet: 10.96.0.0/12   # Kubernetes default
-    # initConfiguration:
-    #   nodeRegistration:
-    #     criSocket: unix:///run/containerd/containerd.sock
-    # joinConfiguration:
-    #   nodeRegistration:
-    #     criSocket: unix:///run/containerd/containerd.sock
 
 stages:
   initramfs:

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -21,6 +21,7 @@ cluster:
   role: init
   config: |
     clusterConfiguration:
+      # IMPORTANT: This version must match KUBEADM_VERSION in the Dockerfile used to build your Kairos image
       kubernetesVersion: v1.34.0
       controlPlaneEndpoint: "192.168.122.71:6443"  # ← SAME IP AS ABOVE
       networking:

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -1,10 +1,19 @@
 #cloud-config
 # Minimal Kairos configuration for worker node
 # IMPORTANT: Use the same control_plane_host as your master node
+hostname: worker-{{ trunc 4 .MachineID }}
+
 install:
   device: "auto"
   auto: true
   reboot: true
+
+users:
+  - name: kairos
+    passwd: kairos
+    groups:
+      - admin
+
 
 cluster:
   cluster_token: "your-cluster-token-here"  # Get from: kubeadm token create

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -22,3 +22,6 @@ stages:
         groups:
           - sudo
         passwd: kairos
+  - commands:
+    # Disable firewalld to prevent Kubernetes networking issues
+    - systemctl disable --now firewalld

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -16,7 +16,7 @@ users:
 
 
 cluster:
-  cluster_token: "your-cluster-token-here"  # Get from: kubeadm token create
+  cluster_token: "your-cluster-token-here"  # Use the same string as your master node
   control_plane_host: 192.168.122.71  # ← SAME IP AS YOUR MASTER NODE
   role: worker
   # config: |  # Let kubeadm auto-detect runtime socket

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -1,0 +1,23 @@
+#cloud-config
+# Minimal Kairos configuration for worker node
+install:
+  device: "auto"
+  auto: true
+  reboot: true
+
+cluster:
+  cluster_token: "your-cluster-token-here"  # Get from: kubeadm token create
+  control_plane_host: 10.10.131.183  # VIP IP for the cluster
+  role: worker
+  # config: |  # Let kubeadm auto-detect runtime socket
+  #   joinConfiguration:
+  #     nodeRegistration:
+  #       criSocket: unix:///run/containerd/containerd.sock
+
+stages:
+  initramfs:
+  - users:
+      kairos:
+        groups:
+          - sudo
+        passwd: kairos

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -19,10 +19,6 @@ cluster:
   cluster_token: "your-cluster-token-here"  # Use the same string as your master node
   control_plane_host: 192.168.122.71  # ← SAME IP AS YOUR MASTER NODE
   role: worker
-  # config: |  # Let kubeadm auto-detect runtime socket
-  #   joinConfiguration:
-  #     nodeRegistration:
-  #       criSocket: unix:///run/containerd/containerd.sock
 
 stages:
   initramfs:

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -1,5 +1,6 @@
 #cloud-config
 # Minimal Kairos configuration for worker node
+# IMPORTANT: Use the same control_plane_host as your master node
 install:
   device: "auto"
   auto: true
@@ -7,7 +8,7 @@ install:
 
 cluster:
   cluster_token: "your-cluster-token-here"  # Get from: kubeadm token create
-  control_plane_host: 10.10.131.183  # VIP IP for the cluster
+  control_plane_host: 192.168.122.71  # ← SAME IP AS YOUR MASTER NODE
   role: worker
   # config: |  # Let kubeadm auto-detect runtime socket
   #   joinConfiguration:


### PR DESCRIPTION
Part of: https://github.com/kairos-io/kairos/issues/3581

This PR adds instructions on how to use this provider and also adds instructions on how to build using kairos-init (and no Earthly).

It should be used as a start to completely removing Earthly in this repository.