### PR TITLE
Make provider-kubadm work with spegel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=quay.io/kairos/fedora:40-core-amd64-generic-v3.5.1
 # (e.g., kairos-master-minimal.yaml, kairos-worker-minimal.yaml)
 ARG KUBEADM_VERSION=latest
 ARG CRICTL_VERSION=1.25.0
-ARG RELEASE_VERSION=0.4.0 # Update to 0.18.0?  https://github.com/kubernetes/release/releases/tag/v0.18.0
+ARG RELEASE_VERSION=0.4.0 # Update newer? e.g. https://github.com/kubernetes/release/releases/tag/v0.18.0
 ARG FIPS_ENABLED=false
 ARG KAIROS_INIT_VERSION=v0.6.0
 ARG VERSION=latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=quay.io/kairos/fedora:40-core-amd64-generic-v3.5.1
 # (e.g., kairos-master-minimal.yaml, kairos-worker-minimal.yaml)
 ARG KUBEADM_VERSION=latest
 ARG CRICTL_VERSION=1.25.0
-ARG RELEASE_VERSION=0.4.0
+ARG RELEASE_VERSION=0.4.0 # Update to 0.18.0?  https://github.com/kubernetes/release/releases/tag/v0.18.0
 ARG FIPS_ENABLED=false
 ARG KAIROS_INIT_VERSION=v0.6.0
 ARG VERSION=latest
@@ -85,14 +85,14 @@ WORKDIR /containerd
 RUN if [ "$FIPS_ENABLED" = "true" ]; then \
         curl -sSL "https://storage.googleapis.com/spectro-fips/containerd/v1.6.4/containerd-1.6.4-linux-amd64.tar.gz" | tar -xz; \
     else \
-        curl -sSL "https://github.com/containerd/containerd/releases/download/v1.6.4/containerd-1.6.4-linux-amd64.tar.gz" | tar -xz; \
+        curl -sSL "https://github.com/containerd/containerd/releases/download/v2.1.4/containerd-2.1.4-linux-amd64.tar.gz" | tar -xz; \
     fi
 
 # Download runc
 RUN if [ "$FIPS_ENABLED" = "true" ]; then \
         curl -SL -o runc "https://storage.googleapis.com/spectro-fips/runc-1.1.4/runc"; \
     else \
-        curl -SL -o runc "https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64"; \
+        curl -SL -o runc "https://github.com/opencontainers/runc/releases/download/v1.3.0/runc.amd64"; \
     fi
 
 RUN chmod +x runc
@@ -102,7 +102,7 @@ RUN mkdir -p cni-plugins && \
     if [ "$FIPS_ENABLED" = "true" ]; then \
         curl -sSL "https://storage.googleapis.com/spectro-fips/cni-plugins/v1.1.1/cni-plugins-1.1.1-linux-amd64.tar.gz" | tar -C cni-plugins -xz; \
     else \
-        curl -sSL "https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz" | tar -C cni-plugins -xz; \
+        curl -sSL "https://github.com/containernetworking/plugins/releases/download/v1.8.0/cni-plugins-linux-amd64-v1.8.0.tgz" | tar -C cni-plugins -xz; \
     fi
 
 # Stage 5: Main image

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -28,6 +28,8 @@ cluster:
         podSubnet: 10.244.0.0/16      # Flannel default
         serviceSubnet: 10.96.0.0/12   # Kubernetes default
 
+# There are settings needed to get spegel to work (https://spegel.dev/docs/getting-started/)
+# Feel free to remove these if you don't need them.
 write_files:
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/kairos-master-minimal.yaml
+++ b/kairos-master-minimal.yaml
@@ -28,6 +28,27 @@ cluster:
         podSubnet: 10.244.0.0/16      # Flannel default
         serviceSubnet: 10.96.0.0/12   # Kubernetes default
 
+write_files:
+- path: /etc/containerd/config.toml
+  permissions: "0644"
+  content: |
+    version = 2
+    root="/opt/containerd"
+    imports = ["/etc/containerd/conf.d/*.toml"]
+
+    [plugins]
+      [plugins."io.containerd.grpc.v1.cri"]
+        sandbox_image = "k8s.gcr.io/pause:3.6"
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = "/opt/bin/runc"
+            SystemdCgroup = true
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
+        [plugins."io.containerd.grpc.v1.cri".containerd]
+          discard_unpacked_layers = false
+
 stages:
   initramfs:
   - users:
@@ -39,3 +60,9 @@ stages:
     - ln -s /etc/kubernetes/admin.conf /run/kubeconfig
     # Disable firewalld to prevent Kubernetes networking issues
     - systemctl disable --now firewalld
+    # Create containerd registry config directory
+    - mkdir -p /etc/containerd/certs.d
+  boot:
+  - commands:
+    # Restart containerd to pick up new registry configuration
+    - systemctl restart containerd

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -20,6 +20,8 @@ cluster:
   control_plane_host: 192.168.122.71  # ← SAME IP AS YOUR MASTER NODE
   role: worker
 
+# There are settings needed to get spegel to work (https://spegel.dev/docs/getting-started/)
+# Feel free to remove these if you don't need them.
 write_files:
 - path: /etc/containerd/config.toml
   permissions: "0644"

--- a/kairos-worker-minimal.yaml
+++ b/kairos-worker-minimal.yaml
@@ -20,6 +20,27 @@ cluster:
   control_plane_host: 192.168.122.71  # ← SAME IP AS YOUR MASTER NODE
   role: worker
 
+write_files:
+- path: /etc/containerd/config.toml
+  permissions: "0644"
+  content: |
+    version = 2
+    root="/opt/containerd"
+    imports = ["/etc/containerd/conf.d/*.toml"]
+
+    [plugins]
+      [plugins."io.containerd.grpc.v1.cri"]
+        sandbox_image = "k8s.gcr.io/pause:3.6"
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = "/opt/bin/runc"
+            SystemdCgroup = true
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
+        [plugins."io.containerd.grpc.v1.cri".containerd]
+          discard_unpacked_layers = false
+
 stages:
   initramfs:
   - users:
@@ -30,3 +51,9 @@ stages:
   - commands:
     # Disable firewalld to prevent Kubernetes networking issues
     - systemctl disable --now firewalld
+    # Create containerd registry config directory
+    - mkdir -p /etc/containerd/certs.d
+  boot:
+  - commands:
+    # Restart containerd to pick up new registry configuration
+    - systemctl restart containerd


### PR DESCRIPTION
[Spegel](https://spegel.dev/docs/getting-started) needs newer versions of containerd et al. It also needs some additional settings.

Let's put them in the example configuration to make it easier for people to replicate. We will need to document it here as well:  https://kairos.io/docs/examples/bandwidth-optimized-upgrades/

Part of this: https://github.com/kairos-io/kairos/issues/3581
