### PR TITLE
fix: ensure compatibility of aarch64 architecture with crane

### DIFF
--- a/scripts/kube-images-load.sh
+++ b/scripts/kube-images-load.sh
@@ -12,6 +12,10 @@ set -ex
 KUBE_VERSION=$1
 
 ARCH=$(uname -m)
+# Convert aarch64 to arm64 for go-containerregistry compatibility
+if [ "$ARCH" = "aarch64" ]; then
+  ARCH="arm64"
+fi
 OS=$(uname)
 ARCHIVE_NAME=go-containerregistry_"${OS}"_"${ARCH}".tar.gz
 TEMP_DIR=/opt/kubeadm-temp


### PR DESCRIPTION
We were having issues building arm64 images using this repo due to an architecture mismatch of the crane installation.
I propose adding a simple check and remap of the `aarch64` output of `uname -m` and set it to `arm64` as released on https://github.com/google/go-containerregistry/releases/tag/v0.13.0

## How to reproduce the issue

If you clone the latest version 4.7.4 and run the build as shown in the readme
``` shell
docker build \
  --build-arg KUBEADM_VERSION=v1.32.0 \
  --build-arg VERSION=v4.7.0-rc.4 \
  --build-arg TARGETARCH=arm64 \
  --platform linux/arm64 \
  -t ${IMAGE_NAME}-arm64:latest \
  .
```

You'll get the following error due to the file not existing `go-containerregistry_Linux_aarch64.tar.gz`
```
0.083 + curl -L -o go-containerregistry_Linux_aarch64.tar.gz https://github.com/google/go-containerregistry/releases/download/v0.13.0/go-containerregistry_Linux_aarch64.tar.gz
0.086   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
0.086                                  Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0     41      0 --:--:-- --:--:-- --:--:--    40
0.306 + tar -xvf go-containerregistry_Linux_aarch64.tar.gz crane
0.307 tar: This does not look like a tar archive
```