### PR TITLE
feat: etcd STIG ownership and permissions (CNTR-K8-003120 / CNTR-K8-003260)

### DIFF
--- a/domain/cluster_context.go
+++ b/domain/cluster_context.go
@@ -13,6 +13,7 @@ type ClusterContext struct {
 	LocalImagesPath             string `json:"localImagesPath" yaml:"localImagesPath"`
 	CustomNodeIp                string `json:"customNodeIp" yaml:"customNodeIp"`
 	ContainerdServiceFolderName string `json:"containerdServiceFolderName" yaml:"containerdServiceFolderName"`
+	EtcdDataDir                 string `json:"etcdDataDir" yaml:"etcdDataDir"`
 
 	EnvConfig map[string]string `json:"envConfig" yaml:"envConfig"`
 }

--- a/domain/constants.go
+++ b/domain/constants.go
@@ -3,6 +3,7 @@ package domain
 const (
 	DefaultAPIAdvertiseAddress = "0.0.0.0"
 
-	ClusterRootPath = "cluster_root_path"
-	DefaultRootPath = "/"
+	ClusterRootPath    = "cluster_root_path"
+	DefaultRootPath    = "/"
+	DefaultEtcdDataDir = "/var/lib/etcd"
 )

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func CreateClusterContext(cluster clusterplugin.Cluster) *domain.ClusterContext 
 		ClusterToken:                utils.TransformToken(cluster.ClusterToken),
 		UserOptions:                 cluster.Options,
 		ContainerdServiceFolderName: getContainerdServiceFolderName(cluster.ProviderOptions),
+		EtcdDataDir:                 domain.DefaultEtcdDataDir,
 	}
 
 	if cluster.LocalImagesPath == "" {
@@ -128,6 +129,10 @@ func getV1Beta3FinalStage(clusterCtx *domain.ClusterContext) []yip.Stage {
 	if clusterCtx.UserOptions != "" {
 		userOptions, _ := kyaml.YAMLToJSON([]byte(clusterCtx.UserOptions))
 		_ = json.Unmarshal(userOptions, &kubeadmConfig)
+	}
+
+	if kubeadmConfig.ClusterConfiguration.Etcd.Local != nil && kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir != "" {
+		clusterCtx.EtcdDataDir = kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir
 	}
 
 	setClusterSubnetCtx(clusterCtx, kubeadmConfig.ClusterConfiguration.Networking.ServiceSubnet, kubeadmConfig.ClusterConfiguration.Networking.PodSubnet)
@@ -152,6 +157,10 @@ func getV1Beta4FinalStage(clusterCtx *domain.ClusterContext) []yip.Stage {
 	if clusterCtx.UserOptions != "" {
 		userOptions, _ := kyaml.YAMLToJSON([]byte(clusterCtx.UserOptions))
 		_ = json.Unmarshal(userOptions, &kubeadmConfig)
+	}
+	
+	if kubeadmConfig.ClusterConfiguration.Etcd.Local != nil && kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir != "" {
+		clusterCtx.EtcdDataDir = kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir
 	}
 
 	setClusterSubnetCtx(clusterCtx, kubeadmConfig.ClusterConfiguration.Networking.ServiceSubnet, kubeadmConfig.ClusterConfiguration.Networking.PodSubnet)

--- a/main.go
+++ b/main.go
@@ -79,16 +79,28 @@ func handleClusterReset(event *pluggable.Event) pluggable.EventResponse {
 	return response
 }
 
+func parseEtcdDataDir(userOptionsJSON []byte, defaultDir string) string {
+	var configV3 domain.KubeadmConfigBeta3
+	_ = json.Unmarshal(userOptionsJSON, &configV3)
+	if configV3.ClusterConfiguration.Etcd.Local != nil && configV3.ClusterConfiguration.Etcd.Local.DataDir != "" {
+		return configV3.ClusterConfiguration.Etcd.Local.DataDir
+	}
+
+	var configV4 domain.KubeadmConfigBeta4
+	_ = json.Unmarshal(userOptionsJSON, &configV4)
+	if configV4.ClusterConfiguration.Etcd.Local != nil && configV4.ClusterConfiguration.Etcd.Local.DataDir != "" {
+		return configV4.ClusterConfiguration.Etcd.Local.DataDir
+	}
+
+	return defaultDir
+}
+
 func cleanupEtcd(userOptions string) {
 	etcdDataDir := domain.DefaultEtcdDataDir
 
 	if userOptions != "" {
-		var kubeadmConfig domain.KubeadmConfigBeta3
 		if userOptionsJSON, err := kyaml.YAMLToJSON([]byte(userOptions)); err == nil {
-			_ = json.Unmarshal(userOptionsJSON, &kubeadmConfig)
-		}
-		if kubeadmConfig.ClusterConfiguration.Etcd.Local != nil && kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir != "" {
-			etcdDataDir = kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir
+			etcdDataDir = parseEtcdDataDir(userOptionsJSON, etcdDataDir)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -74,33 +74,32 @@ func handleClusterReset(event *pluggable.Event) pluggable.EventResponse {
 		response.Error = fmt.Sprintf("failed to reset cluster: %s", string(output))
 	}
 
-	cleanupEtcd(config.Cluster.Options)
+	cleanupEtcd(clusterRootPath, config.Cluster.Options)
 
 	return response
 }
 
-func parseEtcdDataDir(userOptionsJSON []byte, defaultDir string) string {
-	var configV3 domain.KubeadmConfigBeta3
-	_ = json.Unmarshal(userOptionsJSON, &configV3)
-	if configV3.ClusterConfiguration.Etcd.Local != nil && configV3.ClusterConfiguration.Etcd.Local.DataDir != "" {
-		return configV3.ClusterConfiguration.Etcd.Local.DataDir
-	}
-
-	var configV4 domain.KubeadmConfigBeta4
-	_ = json.Unmarshal(userOptionsJSON, &configV4)
-	if configV4.ClusterConfiguration.Etcd.Local != nil && configV4.ClusterConfiguration.Etcd.Local.DataDir != "" {
-		return configV4.ClusterConfiguration.Etcd.Local.DataDir
-	}
-
-	return defaultDir
-}
-
-func cleanupEtcd(userOptions string) {
+func cleanupEtcd(clusterRootPath, userOptions string) {
 	etcdDataDir := domain.DefaultEtcdDataDir
 
 	if userOptions != "" {
-		if userOptionsJSON, err := kyaml.YAMLToJSON([]byte(userOptions)); err == nil {
-			etcdDataDir = parseEtcdDataDir(userOptionsJSON, etcdDataDir)
+		userOptionsJSON, _ := kyaml.YAMLToJSON([]byte(userOptions))
+
+		cmpResult, err := utils.IsKubeadmVersionGreaterThan131(clusterRootPath)
+		if err != nil {
+			logrus.Warnf("failed to check kubeadm version: %v", err)
+		} else if cmpResult < 0 {
+			var kubeadmConfig domain.KubeadmConfigBeta3
+			_ = json.Unmarshal(userOptionsJSON, &kubeadmConfig)
+			if kubeadmConfig.ClusterConfiguration.Etcd.Local != nil && kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir != "" {
+				etcdDataDir = kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir
+			}
+		} else {
+			var kubeadmConfig domain.KubeadmConfigBeta4
+			_ = json.Unmarshal(userOptionsJSON, &kubeadmConfig)
+			if kubeadmConfig.ClusterConfiguration.Etcd.Local != nil && kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir != "" {
+				etcdDataDir = kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -109,12 +109,6 @@ func cleanupEtcd(clusterRootPath, userOptions string) {
 	} else {
 		logrus.Infof("removed etcd data directory: %s", etcdDataDir)
 	}
-	// Also remove default path if a custom one was configured
-	if etcdDataDir != domain.DefaultEtcdDataDir {
-		if err := os.RemoveAll(domain.DefaultEtcdDataDir); err != nil {
-			logrus.Warnf("failed to remove default etcd data directory: %v", err)
-		}
-	}
 
 	// Remove etcd user and group
 	if _, err := user.Lookup("etcd"); err == nil {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 
 	"github.com/kairos-io/kairos/provider-kubeadm/log"
@@ -72,7 +74,52 @@ func handleClusterReset(event *pluggable.Event) pluggable.EventResponse {
 		response.Error = fmt.Sprintf("failed to reset cluster: %s", string(output))
 	}
 
+	cleanupEtcd(config.Cluster.Options)
+
 	return response
+}
+
+func cleanupEtcd(userOptions string) {
+	etcdDataDir := domain.DefaultEtcdDataDir
+
+	if userOptions != "" {
+		var kubeadmConfig domain.KubeadmConfigBeta3
+		if userOptionsJSON, err := kyaml.YAMLToJSON([]byte(userOptions)); err == nil {
+			_ = json.Unmarshal(userOptionsJSON, &kubeadmConfig)
+		}
+		if kubeadmConfig.ClusterConfiguration.Etcd.Local != nil && kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir != "" {
+			etcdDataDir = kubeadmConfig.ClusterConfiguration.Etcd.Local.DataDir
+		}
+	}
+
+	// Remove etcd data directory
+	if err := os.RemoveAll(etcdDataDir); err != nil {
+		logrus.Warnf("failed to remove etcd data directory %s: %v", etcdDataDir, err)
+	} else {
+		logrus.Infof("removed etcd data directory: %s", etcdDataDir)
+	}
+	// Also remove default path if a custom one was configured
+	if etcdDataDir != domain.DefaultEtcdDataDir {
+		if err := os.RemoveAll(domain.DefaultEtcdDataDir); err != nil {
+			logrus.Warnf("failed to remove default etcd data directory: %v", err)
+		}
+	}
+
+	// Remove etcd user and group
+	if _, err := user.Lookup("etcd"); err == nil {
+		if out, err := exec.Command("userdel", "etcd").CombinedOutput(); err != nil {
+			logrus.Warnf("failed to delete etcd user: %s", string(out))
+		} else {
+			logrus.Info("deleted etcd user")
+		}
+	}
+	if _, err := user.LookupGroup("etcd"); err == nil {
+		if out, err := exec.Command("groupdel", "etcd").CombinedOutput(); err != nil {
+			logrus.Warnf("failed to delete etcd group: %s", string(out))
+		} else {
+			logrus.Info("deleted etcd group")
+		}
+	}
 }
 
 func clusterProvider(cluster clusterplugin.Cluster) yip.YipConfig {

--- a/scripts/kube-reset.sh
+++ b/scripts/kube-reset.sh
@@ -10,15 +10,6 @@ fi
 export PATH="$PATH:$STYLUS_ROOT/usr/bin"
 export PATH="$PATH:$STYLUS_ROOT/usr/local/bin"
 
-get_etcd_data_dir() {
-  if [[ -f /etc/kubernetes/manifests/etcd.yaml ]]; then
-    grep -- '--data-dir=' /etc/kubernetes/manifests/etcd.yaml | sed 's/.*--data-dir=\([^ "]*\).*/\1/' | head -1
-  fi
-}
-
-# Capture etcd data directory before kubeadm reset removes the manifest
-ETCD_DATA_DIR=$(get_etcd_data_dir)
-
 if [ -S /run/spectro/containerd/containerd.sock ]; then
     kubeadm reset -f --cri-socket unix:///run/spectro/containerd/containerd.sock --cleanup-tmp-dir
 else
@@ -67,18 +58,4 @@ rm -rf ${STYLUS_ROOT}/etc/systemd/system/spectro-containerd.service 2> /dev/null
 rm -rf /var/log/kube*.log
 rm -rf /var/log/apiserver
 rm -rf /var/log/pods
-
-# Cleanup etcd data directory
-if [[ -n "$ETCD_DATA_DIR" && -d "$ETCD_DATA_DIR" ]]; then
-  rm -rf "$ETCD_DATA_DIR"
-fi
-rm -rf /var/lib/etcd
-
-# Cleanup etcd user and group
-if id "etcd" &>/dev/null; then
-  userdel etcd
-fi
-if getent group etcd &>/dev/null; then
-  groupdel etcd
-fi
 

--- a/scripts/kube-reset.sh
+++ b/scripts/kube-reset.sh
@@ -10,6 +10,15 @@ fi
 export PATH="$PATH:$STYLUS_ROOT/usr/bin"
 export PATH="$PATH:$STYLUS_ROOT/usr/local/bin"
 
+get_etcd_data_dir() {
+  if [[ -f /etc/kubernetes/manifests/etcd.yaml ]]; then
+    grep -- '--data-dir=' /etc/kubernetes/manifests/etcd.yaml | sed 's/.*--data-dir=\([^ "]*\).*/\1/' | head -1
+  fi
+}
+
+# Capture etcd data directory before kubeadm reset removes the manifest
+ETCD_DATA_DIR=$(get_etcd_data_dir)
+
 if [ -S /run/spectro/containerd/containerd.sock ]; then
     kubeadm reset -f --cri-socket unix:///run/spectro/containerd/containerd.sock --cleanup-tmp-dir
 else
@@ -58,4 +67,18 @@ rm -rf ${STYLUS_ROOT}/etc/systemd/system/spectro-containerd.service 2> /dev/null
 rm -rf /var/log/kube*.log
 rm -rf /var/log/apiserver
 rm -rf /var/log/pods
+
+# Cleanup etcd data directory
+if [[ -n "$ETCD_DATA_DIR" && -d "$ETCD_DATA_DIR" ]]; then
+  rm -rf "$ETCD_DATA_DIR"
+fi
+rm -rf /var/lib/etcd
+
+# Cleanup etcd user and group
+if id "etcd" &>/dev/null; then
+  userdel etcd
+fi
+if getent group etcd &>/dev/null; then
+  groupdel etcd
+fi
 

--- a/stages/etcd.go
+++ b/stages/etcd.go
@@ -1,0 +1,40 @@
+package stages
+
+import (
+	"fmt"
+
+	"github.com/kairos-io/kairos/provider-kubeadm/domain"
+	yip "github.com/mudler/yip/pkg/schema"
+)
+
+func GetPreKubeadmEtcdUserStages(clusterCtx *domain.ClusterContext) []yip.Stage {
+	etcdDataDir := clusterCtx.EtcdDataDir
+
+	return []yip.Stage{
+		{
+			Name: "Create etcd user and group (CNTR-K8-003120)",
+			Users: map[string]yip.User{
+				"etcd": {
+					System:       true,
+					PrimaryGroup: "etcd",
+					NoCreateHome: true,
+					Shell:        "/sbin/nologin",
+				},
+			},
+		},
+		{
+			Name: "Set etcd data directory ownership and permissions (CNTR-K8-003260)",
+			Directories: []yip.Directory{
+				{
+					Path:        etcdDataDir,
+					Permissions: 0700,
+				},
+			},
+			Commands: []string{
+				fmt.Sprintf("chown -R etcd:etcd %s", etcdDataDir),
+				fmt.Sprintf("chmod 700 %s", etcdDataDir),
+				fmt.Sprintf("find %s -type f -exec chmod 600 {} \\; 2>/dev/null || true", etcdDataDir),
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GetPreKubeadmEtcdUserStages` to create etcd system user/group via yip `Users` stage (CNTR-K8-003120)
- Ensure etcd data directory exists with `0700` permissions, `etcd:etcd` ownership, and `0600` file permissions (CNTR-K8-003260)
- Add `EtcdDataDir` to `ClusterContext` with default `/var/lib/etcd`, overridable from kubeadm config
- Clean up etcd data directory, user, and group on cluster reset in `handleClusterReset`, parsing the kubeadm config (v1beta3/v1beta4) to resolve the correct data directory

## Test plan
- [ ] Verify etcd user and group are created on init node
- [ ] Verify etcd data directory is created with 700 permissions
- [ ] Verify etcd data directory ownership is etcd:etcd
- [ ] Verify files within etcd data directory have 600 permissions
- [ ] Verify custom `etcd.local.dataDir` from kubeadm config is respected
- [ ] Verify etcd user, group, and data directory are removed on cluster reset
- [ ] Verify reset cleanup works with both kubeadm < 1.31 (v1beta3) and >= 1.31 (v1beta4)