### PR TITLE
chore: update golang builder image to hardened image registry

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -27,7 +27,7 @@ build-cosign:
     SAVE ARTIFACT /ko-app/cosign cosign
 
 go-deps:
-    FROM us-docker.pkg.dev/palette-images/build-base-images/golang:${GOLANG_VERSION}-alpine
+    FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang:${GOLANG_VERSION}-alpine
     WORKDIR /build
     COPY go.mod go.sum ./
     RUN go mod download
@@ -86,9 +86,8 @@ build-provider-package:
     SAVE IMAGE --push $IMAGE_REPOSITORY/provider-kubeadm:${VERSION}-${TARGETARCH}
 
 lint:
-    FROM golang:$GOLANG_VERSION
+    FROM +go-deps
     RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLINT_VERSION}
-    WORKDIR /build
     COPY . .
     RUN golangci-lint run --timeout=10m
 


### PR DESCRIPTION
## Summary
- Update `go-deps` base image from `us-docker.pkg.dev/palette-images/build-base-images/golang` to `us-central1-docker.pkg.dev/palette-images-dev/hardened-images/builder/golang`
- Update `lint` target to reuse `+go-deps` as base image instead of `golang:$GOLANG_VERSION`

## Test plan
- [ ] Verify `+go-deps` target builds successfully with the new image
- [ ] Verify `+lint` target runs successfully
- [ ] Verify `+build-provider` completes successfully