### PR TITLE
refactor: support custom kubernetes api server port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.7
 
 require (
 	github.com/kairos-io/kairos-sdk v0.5.0
-	github.com/mudler/go-pluggable v0.0.0-20230126220627-7710299a0ae5
 	github.com/mudler/yip v1.16.3
 	github.com/onsi/gomega v1.38.2
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
@@ -52,6 +51,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mudler/go-pluggable v0.0.0-20230126220627-7710299a0ae5 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.7
 
 require (
 	github.com/kairos-io/kairos-sdk v0.5.0
+	github.com/mudler/go-pluggable v0.0.0-20230126220627-7710299a0ae5
 	github.com/mudler/yip v1.16.3
 	github.com/onsi/gomega v1.38.2
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
@@ -51,7 +52,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/mudler/go-pluggable v0.0.0-20230126220627-7710299a0ae5 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -81,4 +81,26 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
+)
+
+replace (
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v1.33.2
+	k8s.io/cloud-provider => k8s.io/cloud-provider v1.33.2
+	k8s.io/code-generator => k8s.io/code-generator v1.33.2
+	k8s.io/controller-manager => k8s.io/controller-manager v1.33.2
+	k8s.io/cri-client => k8s.io/cri-client v1.33.2
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v1.33.2
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v1.33.2
+	k8s.io/endpointslice => k8s.io/endpointslice v1.33.2
+	k8s.io/externaljwt => k8s.io/externaljwt v1.33.2
+	k8s.io/kms => k8s.io/kms v1.33.2
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v1.33.2
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v1.33.2
+	k8s.io/kube-proxy => k8s.io/kube-proxy v1.33.2
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v1.33.2
+	k8s.io/kubectl => k8s.io/kubectl v1.33.2
+	k8s.io/metrics => k8s.io/metrics v1.33.2
+	k8s.io/mount-utils => k8s.io/mount-utils v1.33.2
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v1.33.2
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v1.33.2
 )

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os/exec"
 	"path/filepath"
 
@@ -102,11 +103,17 @@ func clusterProvider(cluster clusterplugin.Cluster) yip.YipConfig {
 }
 
 func CreateClusterContext(cluster clusterplugin.Cluster) *domain.ClusterContext {
+	controlPlaneHost := cluster.ControlPlaneHost
+
+	if _, _, err := net.SplitHostPort(controlPlaneHost); err != nil {
+		controlPlaneHost = net.JoinHostPort(controlPlaneHost, "6443")
+	}
+
 	clusterContext := &domain.ClusterContext{
 		RootPath:                    utils.GetClusterRootPath(cluster),
 		NodeRole:                    string(cluster.Role),
 		EnvConfig:                   cluster.Env,
-		ControlPlaneHost:            cluster.ControlPlaneHost,
+		ControlPlaneHost:            controlPlaneHost,
 		ClusterToken:                utils.TransformToken(cluster.ClusterToken),
 		UserOptions:                 cluster.Options,
 		ContainerdServiceFolderName: getContainerdServiceFolderName(cluster.ProviderOptions),

--- a/main_test.go
+++ b/main_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/kairos-io/kairos-sdk/clusterplugin"
-	"github.com/kairos-io/kairos/provider-kubeadm/domain"
 	yip "github.com/mudler/yip/pkg/schema"
 	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/kairos/provider-kubeadm/domain"
 )
 
 // TestCreateClusterContext tests the CreateClusterContext function
@@ -28,7 +29,7 @@ func TestCreateClusterContext(t *testing.T) {
 	// Basic validations
 	g.Expect(result.RootPath).To(Equal("/"))
 	g.Expect(result.NodeRole).To(Equal("init"))
-	g.Expect(result.ControlPlaneHost).To(Equal("10.0.0.1"))
+	g.Expect(result.ControlPlaneHost).To(Equal("10.0.0.1:6443"))
 	// The token is transformed using SHA256 hash, so we just check it's not empty and has the expected format
 	g.Expect(result.ClusterToken).ToNot(BeEmpty())
 	g.Expect(result.ClusterToken).To(MatchRegexp(`^[a-f0-9]{6}\.[a-f0-9]{16}$`))
@@ -62,7 +63,7 @@ func TestCreateClusterContextComprehensive(t *testing.T) {
 			},
 			expectedRootPath:                "/persistent/spectro",
 			expectedNodeRole:                "controlplane",
-			expectedControlPlaneHost:        "192.168.1.100",
+			expectedControlPlaneHost:        "192.168.1.100:6443",
 			expectedContainerdServiceFolder: "containerd",
 			expectedLocalImagesPath:         "/persistent/spectro/opt/content/images",
 		},
@@ -70,7 +71,7 @@ func TestCreateClusterContextComprehensive(t *testing.T) {
 			name: "spectro_containerd_with_custom_images",
 			cluster: clusterplugin.Cluster{
 				Role:             clusterplugin.RoleWorker,
-				ControlPlaneHost: "master.k8s.local",
+				ControlPlaneHost: "master.k8s.local:7443",
 				ClusterToken:     "special-token.1234567890123456",
 				LocalImagesPath:  "/custom/images/path",
 				ProviderOptions: map[string]string{
@@ -85,7 +86,7 @@ func TestCreateClusterContextComprehensive(t *testing.T) {
 			},
 			expectedRootPath:                "/mnt/custom",
 			expectedNodeRole:                "worker",
-			expectedControlPlaneHost:        "master.k8s.local",
+			expectedControlPlaneHost:        "master.k8s.local:7443",
 			expectedContainerdServiceFolder: "spectro-containerd",
 			expectedLocalImagesPath:         "/custom/images/path",
 			validateEnvConfig: func(t *testing.T, env map[string]string) {

--- a/stages/join.go
+++ b/stages/join.go
@@ -12,10 +12,11 @@ import (
 	"github.com/kairos-io/kairos/provider-kubeadm/domain"
 
 	"github.com/kairos-io/kairos-sdk/clusterplugin"
-	"github.com/kairos-io/kairos/provider-kubeadm/utils"
 	yip "github.com/mudler/yip/pkg/schema"
 	"k8s.io/cli-runtime/pkg/printers"
 	kubeadmapiv3 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+
+	"github.com/kairos-io/kairos/provider-kubeadm/utils"
 )
 
 func GetJoinYipStagesV1Beta3(clusterCtx *domain.ClusterContext, kubeadmConfig domain.KubeadmConfigBeta3) []yip.Stage {
@@ -70,7 +71,7 @@ func getJoinNodeConfigurationBeta3(clusterCtx *domain.ClusterContext, joinCfg ku
 	if joinCfg.Discovery.BootstrapToken == nil {
 		joinCfg.Discovery.BootstrapToken = &kubeadmapiv3.BootstrapTokenDiscovery{
 			Token:                    clusterCtx.ClusterToken,
-			APIServerEndpoint:        fmt.Sprintf("%s:6443", clusterCtx.ControlPlaneHost),
+			APIServerEndpoint:        clusterCtx.ControlPlaneHost,
 			UnsafeSkipCAVerification: true,
 		}
 	}
@@ -108,7 +109,7 @@ func getJoinNodeConfigurationBeta4(clusterCtx *domain.ClusterContext, joinCfg ku
 	if joinCfg.Discovery.BootstrapToken == nil {
 		joinCfg.Discovery.BootstrapToken = &kubeadmapiv4.BootstrapTokenDiscovery{
 			Token:                    clusterCtx.ClusterToken,
-			APIServerEndpoint:        fmt.Sprintf("%s:6443", clusterCtx.ControlPlaneHost),
+			APIServerEndpoint:        clusterCtx.ControlPlaneHost,
 			UnsafeSkipCAVerification: true,
 		}
 	}

--- a/utils/defaults.go
+++ b/utils/defaults.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"fmt"
+	"net"
 	"path/filepath"
 	"time"
 
@@ -21,7 +21,7 @@ import (
 
 func MutateClusterConfigBeta3Defaults(clusterCtx *domain.ClusterContext, clusterCfg *kubeadmapiv3.ClusterConfiguration) {
 	clusterCfg.APIServer.CertSANs = appendIfNotPresent(clusterCfg.APIServer.CertSANs, clusterCtx.ControlPlaneHost)
-	clusterCfg.ControlPlaneEndpoint = fmt.Sprintf("%s:6443", clusterCtx.ControlPlaneHost)
+	clusterCfg.ControlPlaneEndpoint = clusterCtx.ControlPlaneHost
 
 	if clusterCfg.ImageRepository == "" {
 		clusterCfg.ImageRepository = kubeadmapiv3.DefaultImageRepository
@@ -29,8 +29,14 @@ func MutateClusterConfigBeta3Defaults(clusterCtx *domain.ClusterContext, cluster
 }
 
 func MutateClusterConfigBeta4Defaults(clusterCtx *domain.ClusterContext, clusterCfg *kubeadmapiv4.ClusterConfiguration) {
-	clusterCfg.APIServer.CertSANs = appendIfNotPresent(clusterCfg.APIServer.CertSANs, clusterCtx.ControlPlaneHost)
-	clusterCfg.ControlPlaneEndpoint = fmt.Sprintf("%s:6443", clusterCtx.ControlPlaneHost)
+	host, _, err := net.SplitHostPort(clusterCtx.ControlPlaneHost)
+	if err != nil {
+		// should not happen, but fail safe:
+		// ControlPlaneHost is already parsed with port.
+		host = clusterCtx.ControlPlaneHost
+	}
+	clusterCfg.APIServer.CertSANs = appendIfNotPresent(clusterCfg.APIServer.CertSANs, host)
+	clusterCfg.ControlPlaneEndpoint = clusterCtx.ControlPlaneHost
 
 	if clusterCfg.ImageRepository == "" {
 		clusterCfg.ImageRepository = kubeadmapiv4.DefaultImageRepository


### PR DESCRIPTION
Closes #181.

By default, the provider was taking for granted the 6443 port: the following changes allow specifying a different port without introducing a breaking change.