### PR TITLE
refactor: drop redundant sudo wrappers from helper scripts

### DIFF
--- a/scripts/kube-reconfigure.sh
+++ b/scripts/kube-reconfigure.sh
@@ -42,9 +42,9 @@ fi
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 regenerate_kube_components_manifests() {
-  sudo -E bash -c "kubeadm init phase control-plane apiserver --config $root_path/opt/kubeadm/cluster-config.yaml"
-  sudo -E bash -c "kubeadm init phase control-plane controller-manager --config $root_path/opt/kubeadm/cluster-config.yaml"
-  sudo -E bash -c "kubeadm init phase control-plane scheduler --config $root_path/opt/kubeadm/cluster-config.yaml"
+  kubeadm init phase control-plane apiserver --config "$root_path"/opt/kubeadm/cluster-config.yaml
+  kubeadm init phase control-plane controller-manager --config "$root_path"/opt/kubeadm/cluster-config.yaml
+  kubeadm init phase control-plane scheduler --config "$root_path"/opt/kubeadm/cluster-config.yaml
 
   kubeadm init phase upload-config kubeadm --config "$root_path"/opt/kubeadm/cluster-config.yaml
 

--- a/scripts/kube-upgrade.sh
+++ b/scripts/kube-upgrade.sh
@@ -153,7 +153,7 @@ run_upgrade() {
         fi
         echo "upgrading node from $old_version to $current_version using command: $upgrade_command"
 
-        if sudo -E bash -c "$upgrade_command"
+        if bash -c "$upgrade_command"
         then
             # Update current client version in the version file
             echo "$current_version" > "$root_path"/opt/sentinel_kubeadmversion


### PR DESCRIPTION
## Summary
- The provider-kubeadm binary runs as root, so the four `sudo -E bash -c "..."` invocations of `kubeadm` in `kube-upgrade.sh` and `kube-reconfigure.sh` are redundant.
- They were also inconsistent with every other command in the same scripts (`systemctl`, `cp`, `chmod`, other `kubeadm init phase ...` calls), none of which use sudo.
- The `-E` flag preserved proxy/PATH env vars across the sudo boundary, but the parent script already `export`s those, so a direct call inherits them.

## Test plan
- [x] `go test ./...` passes
- [x] `bash -n` syntax check on both modified scripts
- [ ] Validate on a real upgrade / reconfigure run