### PR TITLE
strip port from ControlPlaneHost before appending to v1beta3 certSANs

### DIFF
--- a/utils/defaults.go
+++ b/utils/defaults.go
@@ -20,7 +20,13 @@ import (
 )
 
 func MutateClusterConfigBeta3Defaults(clusterCtx *domain.ClusterContext, clusterCfg *kubeadmapiv3.ClusterConfiguration) {
-	clusterCfg.APIServer.CertSANs = appendIfNotPresent(clusterCfg.APIServer.CertSANs, clusterCtx.ControlPlaneHost)
+	host, _, err := net.SplitHostPort(clusterCtx.ControlPlaneHost)
+	if err != nil {
+		// should not happen, but fail safe:
+		// ControlPlaneHost is already parsed with port.
+		host = clusterCtx.ControlPlaneHost
+	}
+	clusterCfg.APIServer.CertSANs = appendIfNotPresent(clusterCfg.APIServer.CertSANs, host)
 	clusterCfg.ControlPlaneEndpoint = clusterCtx.ControlPlaneHost
 
 	if clusterCfg.ImageRepository == "" {

--- a/utils/defaults_test.go
+++ b/utils/defaults_test.go
@@ -16,7 +16,7 @@ func TestMutateClusterConfigBeta3Defaults(t *testing.T) {
 		g := NewWithT(t)
 
 		clusterCtx := &domain.ClusterContext{
-			ControlPlaneHost: "10.0.0.1",
+			ControlPlaneHost: "10.0.0.1:6443",
 			ClusterToken:     "test-token.1234567890123456",
 		}
 
@@ -24,9 +24,11 @@ func TestMutateClusterConfigBeta3Defaults(t *testing.T) {
 
 		MutateClusterConfigBeta3Defaults(clusterCtx, clusterConfig)
 
-		// Validate that the function executes without error
-		// The actual mutations depend on the implementation details
-		g.Expect(clusterConfig).ToNot(BeNil())
+		// certSANs must contain only the host, not host:port
+		g.Expect(clusterConfig.APIServer.CertSANs).To(ContainElement("10.0.0.1"))
+		g.Expect(clusterConfig.APIServer.CertSANs).NotTo(ContainElement("10.0.0.1:6443"))
+		// ControlPlaneEndpoint retains the port
+		g.Expect(clusterConfig.ControlPlaneEndpoint).To(Equal("10.0.0.1:6443"))
 	})
 }
 


### PR DESCRIPTION
## Summary

- Commit db53b15 normalized `ControlPlaneHost` to always include a port (e.g. `10.10.232.243:6443`) and correctly applied `net.SplitHostPort` in `MutateClusterConfigBeta4Defaults` before appending to `certSANs`
- `MutateClusterConfigBeta3Defaults` was missed — it continued appending `host:port` directly to `certSANs`
- kubeadm rejects `"10.10.232.243:6443"` as an invalid SAN, causing `kubeadm init` to fail in an infinite retry loop on Kubernetes ≤ 1.30 clusters (v1beta3 API)