### PR TITLE
fix(PE-8602): start kubelet and wait for API server readiness before upgrade lock

### DIFF
--- a/scripts/kube-upgrade.sh
+++ b/scripts/kube-upgrade.sh
@@ -76,6 +76,24 @@ revert_kubeadm_config() {
   kubeadm init phase upload-config kubeadm --config "$root_path"/opt/kubeadm/existing-cluster-config.yaml
 }
 
+start_kubelet() {
+  if ! systemctl is-enabled --quiet kubelet; then
+    systemctl enable kubelet
+  fi
+
+  if ! systemctl is-active --quiet kubelet; then
+    systemctl start kubelet
+  fi
+
+  echo "waiting for kubelet to be ready"
+  until systemctl is-active --quiet kubelet && kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes >/dev/null 2>&1
+  do
+    echo "kubelet or API server not ready yet, retrying in 10 seconds"
+    sleep 10
+  done
+  echo "kubelet is ready"
+}
+
 run_upgrade() {
     echo "running upgrade process on $NODE_ROLE"
 
@@ -94,6 +112,7 @@ run_upgrade() {
     fi
 
     # Proceed to do upgrade operation
+    start_kubelet
 
     # Try to create an empty configmap in default namespace which will act as a lock, until it succeeds.
     # Once a node creates a configmap, other nodes will remain at this step until the first node deletes the configmap when upgrade completes.


### PR DESCRIPTION
## Summary
- Day-2 k8s upgrades on edge nodes get stuck in an infinite loop after reboot because `apply-control-plan` stops kubelet before rebooting, and on the next boot `kube-upgrade.sh` immediately tries to acquire the upgrade-lock ConfigMap against an unreachable API server
- Add `start_kubelet()` that enables/starts kubelet if not running, then waits until both kubelet is active and the API server responds before entering the upgrade-lock loop

## Root cause
`apply-control-plan` job stops kubelet then reboots. On reboot, `spectro-palette-agent-boot.service` (declared `Before=getty.target`) runs `kube-upgrade.sh` as a oneshot — blocking `multi-user.target`, which is what `kubelet.service` is `WantedBy`. systemd won't start kubelet until the boot service finishes, but the boot service waits for the API server (via kube-vip static pod) that needs kubelet. Classic deadlock, ~700+ retries logged in production.

## Test plan
- [ ] Trigger a Day-2 k8s upgrade on a single control-plane edge node (PXK-E, airgap or connected)
- [ ] Verify node reboots and `kube-upgrade.sh` starts kubelet and waits for API server readiness before attempting ConfigMap lock
- [ ] Verify upgrade completes and cluster converges to new version
- [ ] Verify on plain reboot (no upgrade) that `start_kubelet()` is a no-op (kubelet already active, exits immediately)

Fixes: https://spectrocloud.atlassian.net/browse/PE-8602

🤖 Generated with [Claude Code](https://claude.com/claude-code)