### PR TITLE
fix(PE-9053): make kube-upgrade readiness gate worker-aware

### DIFF
--- a/scripts/kube-upgrade.sh
+++ b/scripts/kube-upgrade.sh
@@ -86,11 +86,21 @@ start_kubelet() {
   fi
 
   echo "waiting for kubelet to be ready"
-  until systemctl is-active --quiet kubelet && kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes >/dev/null 2>&1
-  do
-    echo "kubelet or API server not ready yet, retrying in 10 seconds"
-    sleep 10
-  done
+  # Workers have no admin.conf; probe via kubelet.conf against the self Node
+  # (permitted by the system:node identity's RBAC).
+  if [ "$NODE_ROLE" = "worker" ]; then
+    until systemctl is-active --quiet kubelet && kubectl --kubeconfig /etc/kubernetes/kubelet.conf get node "$CURRENT_NODE_NAME" >/dev/null 2>&1
+    do
+      echo "kubelet or API server not ready yet, retrying in 10 seconds"
+      sleep 10
+    done
+  else
+    until systemctl is-active --quiet kubelet && kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes >/dev/null 2>&1
+    do
+      echo "kubelet or API server not ready yet, retrying in 10 seconds"
+      sleep 10
+    done
+  fi
   echo "kubelet is ready"
 }
 


### PR DESCRIPTION
## Summary

`scripts/kube-upgrade.sh` — worker K8s upgrades hang forever in `start_kubelet()` because the readiness gate probes the cluster with `kubectl --kubeconfig /etc/kubernetes/admin.conf get nodes` on **all** node roles, but workers never have `admin.conf`. The gate command exits non-zero every iteration → loop never terminates → `kubeadm upgrade node` is never reached → node stays on the old version indefinitely.

## Fix

`start_kubelet()` now branches on `NODE_ROLE`:

- **worker** — probe via `kubectl --kubeconfig /etc/kubernetes/kubelet.conf get node "$CURRENT_NODE_NAME"`. The `system:node:<name>` identity carried by `kubelet.conf` is allowed to `get` its own `Node` object, so this satisfies the same "kubelet + API-server reachable" invariant the original gate was after.
- **control-plane** — original probe unchanged, keeping PE-8602's protection intact.

