### PR TITLE
fix: add --local flag to ctr image import for containerd >=2.1

### DIFF
--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -16,13 +16,33 @@ else
   CTR_SOCKET=/run/containerd/containerd.sock
 fi
 
+# containerd >=2.1 defaults ctr image import to the Transfer Service (--local=false).
+# The Transfer Service does not properly register images with the CRI plugin's
+# reference index, so kubelet's ImageStatus call cannot find the image despite it
+# being present in the content store.  This causes imagePullPolicy:IfNotPresent to
+# trigger a registry pull, which fails on airgapped hosts.
+# Adding --local forces the legacy client.Import path that calls ImageService().Create(),
+# populating the CRI index correctly.
+# See: https://github.com/containerd/containerd/issues/9039
+CTR_LOCAL_FLAG=""
+if ctr_version=$(/opt/bin/ctr --version 2>/dev/null); then
+  # Extract version number (e.g. "containerd github.com/containerd/containerd/v2 v2.1.4 ..." → "2.1.4")
+  ver=$(echo "$ctr_version" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+  major=$(echo "$ver" | cut -d. -f1)
+  minor=$(echo "$ver" | cut -d. -f2)
+  if [ "${major:-0}" -ge 2 ] && [ "${minor:-0}" -ge 1 ]; then
+    CTR_LOCAL_FLAG="--local"
+    echo "containerd $ver detected (>=2.1), using --local flag for import"
+  fi
+fi
+
 import_image() {
   local tarfile=$1
   local i=1
 
   echo "Importing: $tarfile"
   for i in {1..10}; do
-    output=$(/opt/bin/ctr -n k8s.io --address $CTR_SOCKET image import "$tarfile" --all-platforms 2>&1)
+    output=$(/opt/bin/ctr -n k8s.io --address $CTR_SOCKET image import "$tarfile" --all-platforms $CTR_LOCAL_FLAG 2>&1)
     exit_code=$?
 
     if [ $exit_code -eq 0 ]; then


### PR DESCRIPTION
## Summary

- Detect containerd version at runtime in `import.sh`
- Add `--local` flag to `ctr image import` when containerd >=2.1 is detected

## Problem

containerd v2.1 changed `ctr image import` to default to the **Transfer Service** (`--local=false`). The Transfer Service does not properly register images with the CRI plugin's internal reference index ([containerd/containerd#9039](https://github.com/containerd/containerd/issues/9039)).

**Breaking change between containerd v2.0.x and v2.1.x:**

| Behavior | containerd v2.0.x | containerd v2.1.x |
|---|---|---|
| `ctr image import` default | Local client import (`--local=true`) | Transfer Service (`--local=false`) |
| Calls `ImageService().Create()` | Yes | **No** |
| CRI `ImageStatus` finds image | Yes | **No** |
| kubelet `IfNotPresent` works | Yes | **No** — forces registry pull |

**Impact on airgapped edge hosts:**

Images loaded via `ctr image import` appear in `crictl images` but are invisible to kubelet's `ImageStatus` check. Pods enter `ImagePullBackOff` despite the image being fully present and unpacked in containerd.

## Fix

Parse `ctr --version` output to detect containerd >=2.1, then pass `--local` to force the legacy import path that calls `ImageService().Create()`. No-op on containerd <2.1.

## Other providers checked

| Provider | Uses `ctr image import`? | Fix needed? |
|---|---|---|
| **provider-kubeadm** | Yes | **Yes** (this PR) |
| **provider-k3s** | No — copies tars to `/var/lib/rancher/k3s/agent/images/` | No |
| **provider-canonical** | No — copies tars to `/var/snap/k8s/common/images/` | No |
| **provider-nodeadm** | No — no import logic | No |

## Companion PR

- stylus: [spectrocloud/stylus#6246](https://github.com/spectrocloud/stylus/pull/6246) — fixes the Go `client.Transfer()` path used by stylus-agent content sync

## Refs

- https://github.com/containerd/containerd/issues/9039
- https://github.com/containerd/containerd/issues/9773
- https://github.com/containerd/containerd/issues/13494

## Test plan

- [ ] Verify boot-time image import works on containerd v2.1.x with `--local` flag
- [ ] Verify `imagePullPolicy: IfNotPresent` pods start without registry pull on airgapped edge hosts
- [ ] Verify no regression on containerd v2.0.x (flag is not added)
- [ ] Verify no regression on containerd v1.x (flag is not added)